### PR TITLE
feat: versioned snapshots

### DIFF
--- a/sync_service/lib/electric/plug/shapes.ex
+++ b/sync_service/lib/electric/plug/shapes.ex
@@ -5,8 +5,8 @@ defmodule Electric.Plug.Shapes do
   alias Electric.Shapes
   require Logger
 
-  plug :match
-  plug :dispatch
+  plug(:match)
+  plug(:dispatch)
 
   get "/:table" do
     conn = Plug.Conn.fetch_query_params(conn)
@@ -23,22 +23,54 @@ defmodule Electric.Plug.Shapes do
       end
 
     cond do
+      # chunk request (with specified offset)
       Map.get(conn.query_params, "offset", "-1") != "-1" ->
-        # FIXME: this raises on non-int offset, so we definitely want to add proper validation here
-        offset = String.to_integer(conn.query_params["offset"])
-        shape_id = Map.fetch!(conn.query_params, "shapeId")
-        unchanged_etag = "#{shape_id}-#{ShapeLogStorage.get_last_offset(shape_id) || 0}"
+        handle_shape_chunk_request(conn, table)
 
-        if get_req_header(conn, "if-none-match") == [unchanged_etag] do
+      # initial request (offset = -1)
+      true ->
+        handle_initial_shape_request(conn, table)
+    end
+  end
+
+  defp handle_shape_chunk_request(conn, table) do
+    # FIXME: this raises on non-int offset, so we definitely want to add proper validation here
+    offset = String.to_integer(conn.query_params["offset"])
+    shape_id = Map.fetch!(conn.query_params, "shapeId")
+
+    cond do
+      # If shape or shape offset not present, we respond with an error and the version of
+      # the new initial shape request to make
+      !ShapeLogStorage.has_offset(shape_id, offset) ->
+        {:ok, shape_id, version, _} = Shapes.get_or_create_shape(table)
+
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(
+          404,
+          Jason.encode_to_iodata!(%{
+            message: "Shape offset not found - request from scratch",
+            offset: -1,
+            shape_id: shape_id,
+            version: version
+          })
+        )
+
+      true ->
+        last_offset = ShapeLogStorage.get_last_offset(shape_id) || 0
+        chunk_etag = "#{shape_id}-#{last_offset}"
+
+        if get_req_header(conn, "if-none-match") == [chunk_etag] do
           send_resp(conn, 304, "")
         else
           # FIXME: we need to validate shape id here - it should match correct shape id for the provided shape definition
           conn =
             conn
             |> put_resp_header("x-electric-shape-id", shape_id)
+            |> put_resp_header("x-electric-chunk-last-offset", "#{last_offset}")
             |> put_resp_content_type("application/json")
 
-          {data, max_offset} =
+          {data, _} =
             ShapeLogStorage.get_log(shape_id, offset)
             |> Enum.map_reduce(0, fn {offset, xid, change}, _ ->
               {%{
@@ -58,7 +90,7 @@ defmodule Electric.Plug.Shapes do
               |> put_resp_header_if(
                 not is_map_key(conn.query_params, "live"),
                 "etag",
-                "#{shape_id}-#{max_offset}"
+                chunk_etag
               )
               |> send_resp(
                 200,
@@ -66,65 +98,69 @@ defmodule Electric.Plug.Shapes do
               )
           end
         end
+    end
+  end
 
-      true ->
-        # FIXME: should have an error handler
-        # FIXME: should not return snapshot immediately
-        {:ok, shape_id, snapshot} = Shapes.get_or_create_shape(table)
+  defp handle_initial_shape_request(conn, table) do
+    # FIXME: should have an error handler
+    # FIXME: should not return snapshot immediately
+    {:ok, shape_id, version, snapshot} = Shapes.get_or_create_shape(table)
 
-        unchanged_etag = "#{shape_id}-#{ShapeLogStorage.get_last_offset(shape_id) || 0}"
+    snapshot_etag = "#{shape_id}-#{version}-#{ShapeLogStorage.get_last_offset(shape_id) || 0}"
 
-        if get_req_header(conn, "if-none-match") == [unchanged_etag] do
-          send_resp(conn, 304, "")
-        else
-          initial_rows =
-            Enum.map(
-              snapshot,
-              &%{
-                key: "public-" <> shape_id <> "-" <> &1["id"],
-                value: &1,
-                headers: %{action: "insert"},
-                offset: 0
+    if get_req_header(conn, "if-none-match") == [snapshot_etag] do
+      send_resp(conn, 304, "")
+    else
+      initial_rows =
+        Enum.map(
+          snapshot,
+          &%{
+            # FIXME: get relation data (namespace?) from the snapshot itself?
+            key: Changes.build_key(%{relation: {"public", table}, record: &1}),
+            value: &1,
+            headers: %{action: "insert"},
+            offset: 0
+          }
+        )
+
+      {active_log, max_offset} =
+        ShapeLogStorage.get_log(shape_id, -1)
+        |> Stream.reject(&is_struct(elem(&1, 2), Changes.TruncatedRelation))
+        |> Enum.map_reduce(0, fn {offset, xid, change}, _ ->
+          {%{
+             key: Changes.build_key(change),
+             value: Changes.to_json_value(change),
+             headers: %{action: Changes.get_action(change), txid: xid},
+             offset: offset
+           }, offset}
+        end)
+
+      start = System.monotonic_time()
+
+      encoded =
+        Jason.encode_to_iodata!(
+          initial_rows ++
+            active_log ++
+            [
+              %{
+                headers: %{control: "up-to-date"}
               }
-            )
+            ]
+        )
 
-          {active_log, max_offset} =
-            ShapeLogStorage.get_log(shape_id, -1, 1000)
-            |> Stream.reject(&is_struct(elem(&1, 2), Changes.TruncatedRelation))
-            |> Enum.map_reduce(0, fn {offset, xid, change}, _ ->
-              {%{
-                 key: Changes.build_key(change),
-                 value: Changes.to_json_value(change),
-                 headers: %{action: Changes.get_action(change), txid: xid},
-                 offset: offset
-               }, offset}
-            end)
+      :telemetry.execute(
+        [:electric, :snapshot],
+        %{encoding: System.monotonic_time() - start},
+        %{}
+      )
 
-          start = System.monotonic_time()
-
-          encoded =
-            Jason.encode_to_iodata!(
-              initial_rows ++
-                active_log ++
-                [
-                  %{
-                    headers: %{control: "up-to-date"}
-                  }
-                ]
-            )
-
-          :telemetry.execute(
-            [:electric, :snapshot],
-            %{encoding: System.monotonic_time() - start},
-            %{}
-          )
-
-          conn
-          |> put_resp_header("x-electric-shape-id", shape_id)
-          |> put_resp_content_type("application/json")
-          |> put_resp_header("etag", "#{shape_id}-#{max_offset}")
-          |> send_resp(200, encoded)
-        end
+      conn
+      |> put_resp_header("x-electric-shape-id", shape_id)
+      |> put_resp_header("x-electric-shape-version", "#{version}")
+      |> put_resp_header("x-electric-chunk-last-offset", "#{max_offset}")
+      |> put_resp_content_type("application/json")
+      |> put_resp_header("etag", snapshot_etag)
+      |> send_resp(200, encoded)
     end
   end
 

--- a/sync_service/lib/electric/replication/shape_log_storage.ex
+++ b/sync_service/lib/electric/replication/shape_log_storage.ex
@@ -26,10 +26,24 @@ defmodule Electric.Replication.ShapeLogStorage do
     end
   end
 
+  def has_offset(shape_id, offset) do
+    case :ets.lookup(@table_name, {shape_id, offset}) do
+      [{_, _, _}] -> true
+      _ -> false
+    end
+  end
+
+  def get_version(shape_id) do
+     case InMemShapeCache.fetch_snapshot(shape_id) do
+        {:ok, _, version, _} -> version
+        _ -> nil
+     end
+  end
+
   @spec get_log(String.t(), integer(), non_neg_integer() | :infinity) ::
           Enumerable.t(
             {position :: non_neg_integer(), transaction_id :: non_neg_integer(),
-             change :: Changes.change()}
+      change :: Changes.change()}
           )
   def get_log(shape_id, offset, size \\ :infinity) do
     Stream.unfold({offset, size}, fn

--- a/sync_service/lib/electric/shapes.ex
+++ b/sync_service/lib/electric/shapes.ex
@@ -34,8 +34,8 @@ defmodule Electric.Shapes do
     shape_cache = Keyword.get(opts, :shape_cache, Electric.InMemShapeCache)
 
     case shape_cache.fetch_snapshot(table) do
-      {:ok, shape_id, snapshot} ->
-        {:ok, shape_id, snapshot}
+      {:ok, shape_id, version, snapshot} ->
+        {:ok, shape_id, version, snapshot}
 
       :error ->
         case shape_cache.create_or_wait_snapshot(table) do


### PR DESCRIPTION
This PR modifies the sync service to keep track of the version of the snapshot of a shape. The version is the monotonic time. When a client comes in with a shape ID that does not exists or an offset that is out of scope, we get or create the shape and refer them to the latest version for them to do a new initial sync.