### PR TITLE
feat: Handle missing log entries due to cached requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ wal
 test-dbs
 shape-data.json
 caching/nginx_cache
+.vscode

--- a/client.ts
+++ b/client.ts
@@ -27,11 +27,11 @@ export interface BackoffOptions {
 const BackoffDefaults = {
   initialDelay: 100,
   maxDelay: 10_000,
-  multiplier: 1.3
+  multiplier: 1.3,
 }
 
 export interface ShapeStreamOptions extends ShapeOptions {
-  shape: ShapeDefinition,
+  shape: ShapeDefinition
   subscribe?: boolean
   signal?: AbortSignal
 }
@@ -108,7 +108,7 @@ export class ShapeStream {
 
   private instanceId: number
   private subscribers: Map = new Map<string, MessageProcessor>()
-  private upToDateSubscribers: Map = new Map<string, () => void>();
+  private upToDateSubscribers: Map = new Map<string, () => void>()
 
   private closedPromise: Promise<unknown>
   private outsideResolve?: (value?: unknown) => void
@@ -116,7 +116,7 @@ export class ShapeStream {
   private pausedPromise?: Promise<unknown>
   private pausedResolve?: (value?: unknown) => void
 
-  private lastOffset:Number
+  private lastOffset: Number
   private hasBeenUpToDate: Boolean = false
   private isUpToDate: Boolean = false
 
@@ -127,7 +127,10 @@ export class ShapeStream {
 
   shapeId?: string
 
-  constructor(options: ShapeStreamOptions, backoffOptions: BackoffOptions = BackoffDefaults) {
+  constructor(
+    options: ShapeStreamOptions,
+    backoffOptions: BackoffOptions = BackoffDefaults
+  ) {
     this.instanceId = Math.random()
 
     this.validateOptions(options)
@@ -144,7 +147,7 @@ export class ShapeStream {
     })
   }
 
-  setLiveMode (value: Boolean) {
+  setLiveMode(value: Boolean) {
     this.liveMode = value
   }
 
@@ -219,15 +222,13 @@ export class ShapeStream {
               })
             }
           })
-      }
-      catch (e) {
+      } catch (e) {
         if (signal?.aborted) {
           // Break out of while loop when the user aborts the client.
           this.isPaused = false
 
           break
-        }
-        else {
+        } else {
           // Exponentially backoff on errors.
           // Wait for the current delay duration
           await new Promise((resolve) => setTimeout(resolve, delay))
@@ -241,7 +242,7 @@ export class ShapeStream {
       }
     }
 
-    if (!(this.isPaused)) {
+    if (!this.isPaused) {
       this.outsideResolve && this.outsideResolve()
     }
   }
@@ -254,7 +255,7 @@ export class ShapeStream {
     return this.closedPromise
   }
 
-  async pause () {
+  async pause() {
     this.pausedPromise = new Promise((resolve) => {
       this.pausedResolve = resolve
     })
@@ -264,7 +265,7 @@ export class ShapeStream {
     return pausedPromise
   }
 
-  async resume () {
+  async resume() {
     return this.start()
   }
 
@@ -304,7 +305,9 @@ export class ShapeStream {
   }
 
   private notifyUpToDateSubscribers() {
-    this.upToDateSubscribers.forEach((callback) => { callback() })
+    this.upToDateSubscribers.forEach((callback) => {
+      callback()
+    })
   }
 
   private validateOptions(options: ShapeStreamOptions): void {
@@ -399,11 +402,15 @@ export class Shape {
   private stream: ShapeStream
 
   private data: ShapeData = new Map()
-  private subscribers = new Map<string, ShapeChangedCallback>();
+  private subscribers = new Map<string, ShapeChangedCallback>()
 
   private isSyncing = false
 
-  constructor(definition: ShapeDefinition, options: ShapeOptions, backoffOptions?: BackoffOptions) {
+  constructor(
+    definition: ShapeDefinition,
+    options: ShapeOptions,
+    backoffOptions?: BackoffOptions
+  ) {
     this.aborter = new AbortController()
     this.definition = definition
 
@@ -428,8 +435,7 @@ export class Shape {
     return new Promise((resolve) => {
       if (this.stream.hasBeenUpToDate) {
         resolve(this.value)
-      }
-      else {
+      } else {
         this.stream.subscribeOnceToUpToDate(() => {
           resolve(this.value)
         })
@@ -441,8 +447,7 @@ export class Shape {
     return new Promise((resolve) => {
       if (this.stream.isUpToDate) {
         resolve(this.value)
-      }
-      else {
+      } else {
         this.stream.subscribeOnceToUpToDate(() => {
           resolve(this.value)
         })

--- a/sync_service/.env.dev
+++ b/sync_service/.env.dev
@@ -1,8 +1,4 @@
-AUTH_MODE=insecure
-DATABASE_REQUIRE_SSL=false
 DATABASE_URL=postgresql://postgres:password@localhost:54321/electric
-ELECTRIC_TELEMETRY=0
 ENABLE_INTEGRATION_TESTING=true
-LOG_LEVEL=debug
-LOGICAL_PUBLISHER_HOST=host.docker.internal
-PG_PROXY_PASSWORD=proxy_password
+CACHE_MAX_AGE=1
+CACHE_STALE_AGE=3

--- a/sync_service/config/runtime.exs
+++ b/sync_service/config/runtime.exs
@@ -18,10 +18,14 @@ else
 end
 
 enable_integration_testing = env!("ENABLE_INTEGRATION_TESTING", :boolean, false)
+cache_max_age = env!("CACHE_MAX_AGE", :integer, 60)
+cache_stale_age = env!("CACHE_STALE_AGE", :integer, 60 * 5)
 statsd_host = env!("STATSD_HOST", :string?, nil)
 
 config :electric,
   allow_shape_deletion: enable_integration_testing,
+  cache_max_age: cache_max_age,
+  cache_stale_age: cache_stale_age,
   # Used in telemetry
   environment: config_env(),
   instance_id: env!("ELECTRIC_INSTANCE_ID", :string, Electric.Utils.uuid4()),

--- a/sync_service/lib/electric/application.ex
+++ b/sync_service/lib/electric/application.ex
@@ -44,7 +44,9 @@ defmodule Electric.Application do
                 storage: storage,
                 registry: Registry.ShapeChanges,
                 shape_cache: {Electric.ShapeCache, []},
-                long_poll_timeout: 20_000},
+                long_poll_timeout: 20_000,
+                max_age: Application.fetch_env!(:electric, :cache_max_age),
+                stale_age: Application.fetch_env!(:electric, :cache_stale_age)},
              port: 3000}
           ]
         else

--- a/sync_service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/sync_service/lib/electric/shape_cache/in_memory_storage.ex
@@ -65,6 +65,13 @@ defmodule Electric.ShapeCache.InMemoryStorage do
     end)
   end
 
+  def has_log_entry?(shape_id, offset, opts) do
+    case :ets.select(opts.log_ets_table, [{{{shape_id, offset}, :_, :_, :_, :_}, [], [true]}]) do
+      [] -> false
+      [true] -> true
+    end
+  end
+
   @spec make_new_snapshot!(String.t(), Postgrex.Query.t(), Enumerable.t(), map()) :: :ok
   def make_new_snapshot!(shape_id, query_info, data_stream, opts) do
     ets_table = opts.snapshot_ets_table

--- a/sync_service/lib/electric/shape_cache/storage.ex
+++ b/sync_service/lib/electric/shape_cache/storage.ex
@@ -45,6 +45,8 @@ defmodule Electric.ShapeCache.Storage do
             ) :: :ok
   @doc "Get stream of the log for a shape since a given offset"
   @callback get_log_stream(shape_id(), integer(), compiled_opts()) :: Enumerable.t()
+  @doc "Check if log entry for given shape ID and offset exists"
+  @callback has_log_entry?(shape_id(), integer(), compiled_opts()) :: boolean()
   @doc "Clean up snapshots/logs for a shape id"
   @callback cleanup!(shape_id(), compiled_opts()) :: :ok
 
@@ -85,6 +87,11 @@ defmodule Electric.ShapeCache.Storage do
   @spec get_log_stream(shape_id(), integer(), storage()) :: Enumerable.t()
   def get_log_stream(shape_id, offset, {mod, opts}),
     do: apply(mod, :get_log_stream, [shape_id, offset, opts])
+
+  @doc "Check if log entry for given shape ID and offset exists"
+  @spec has_log_entry?(shape_id(), non_neg_integer(), storage()) :: boolean()
+  def has_log_entry?(shape_id, offset, {mod, opts}),
+    do: apply(mod, :has_log_entry?, [shape_id, offset, opts])
 
   @doc "Clean up snapshots/logs for a shape id"
   @spec cleanup!(shape_id(), storage()) :: :ok

--- a/sync_service/lib/electric/shapes.ex
+++ b/sync_service/lib/electric/shapes.ex
@@ -26,10 +26,34 @@ defmodule Electric.Shapes do
     Storage.get_log_stream(shape_id, offset, storage)
   end
 
-  @spec get_or_create_shape_id(Shape.t(), keyword()) :: {ShapeCache.shape_id(), non_neg_integer()}
+  @doc """
+  Get or create a shape ID and return it along with the latest
+  offset available
+  """
+  @spec get_or_create_shape_id(Shape.t(), keyword()) :: {Storage.shape_id(), non_neg_integer()}
   def get_or_create_shape_id(shape_def, opts \\ []) do
     {shape_cache, opts} = Access.get(opts, :shape_cache, {ShapeCache, []})
 
     shape_cache.get_or_create_shape_id(shape_def, opts)
+  end
+
+  @doc """
+  Check whether the log has an entry for a given shape ID and offset
+  """
+  @spec has_log_entry?(keyword(), Storage.shape_id(), non_neg_integer()) ::
+          boolean()
+  def has_log_entry?(config, shape_id, offset) do
+    storage = Access.fetch!(config, :storage)
+    Storage.has_log_entry?(shape_id, offset, storage)
+  end
+
+  @doc """
+  Clean up all data (meta data and shape log + snapshot) associated with the given shape ID
+  """
+  @spec clean_shape(Storage.shape_id(), keyword()) :: :ok
+  def clean_shape(shape_id, opts \\ []) do
+    {shape_cache, _} = Keyword.pop(opts, :shape_cache, Electric.ShapeCache)
+    shape_cache.clean_shape(shape_id)
+    :ok
   end
 end

--- a/sync_service/test/electric/shape_cache/in_memory_storage_test.exs
+++ b/sync_service/test/electric/shape_cache/in_memory_storage_test.exs
@@ -193,6 +193,32 @@ defmodule Electric.ShapeCache.InMemoryStorageTest do
     end
   end
 
+  describe "has_log_entry?/3" do
+    test "returns a boolean indicating whether there is a log entry with such an offset", %{
+      opts: opts
+    } do
+      shape_id = "test_shape"
+      lsn = Lsn.from_integer(1000)
+      xid = 1
+
+      changes = [
+        %Changes.NewRecord{
+          relation: {"public", "test_table"},
+          record: %{"id" => "123", "name" => "Test"}
+        }
+      ]
+
+      :ok = InMemoryStorage.append_to_log!(shape_id, lsn, xid, changes, opts)
+
+      assert InMemoryStorage.has_log_entry?(shape_id, 1000, opts)
+      refute InMemoryStorage.has_log_entry?(shape_id, 1001, opts)
+    end
+
+    test "should return false when there is no log", %{opts: opts} do
+      refute InMemoryStorage.has_log_entry?("shape_id", 1001, opts)
+    end
+  end
+
   describe "cleanup!/2" do
     test "removes all data for a shape", %{opts: opts} do
       shape_id = "test_shape"

--- a/sync_service/test/electric/shape_cache/storage_test.exs
+++ b/sync_service/test/electric/shape_cache/storage_test.exs
@@ -15,6 +15,7 @@ defmodule Electric.ShapeCache.StorageTest do
     |> Mox.expect(:get_snapshot, fn _, :opts -> {1, []} end)
     |> Mox.expect(:append_to_log!, fn _, _, _, _, :opts -> :ok end)
     |> Mox.expect(:get_log_stream, fn _, _, :opts -> [] end)
+    |> Mox.expect(:has_log_entry?, fn _, _, :opts -> [] end)
     |> Mox.expect(:cleanup!, fn _, :opts -> :ok end)
 
     Storage.make_new_snapshot!(shape_id, %{}, [], storage)
@@ -22,6 +23,7 @@ defmodule Electric.ShapeCache.StorageTest do
     Storage.get_snapshot(shape_id, storage)
     Storage.append_to_log!(shape_id, 1, 1, [], storage)
     Storage.get_log_stream(shape_id, -1, storage)
+    Storage.has_log_entry?(shape_id, 1, storage)
     Storage.cleanup!(shape_id, storage)
   end
 end


### PR DESCRIPTION
Adds handling for cases where requests come in requesting a specific offset for a shape that either doesn't exist anymore (out of scope) - it was either cleaned up because it went out of scope or compacted and no longer has the requested offset entries in the log

Implemented dumb endpoint for cleaning up the shape data to avoid getting into the scheduled cleanup of shapes

Co-authored with @kevin-dp 