### PR TITLE
sync service: fix regression that broke the actual API.

### DIFF
--- a/sync_service/lib/electric/plug/router.ex
+++ b/sync_service/lib/electric/plug/router.ex
@@ -10,8 +10,8 @@ defmodule Electric.Plug.Router do
 
   head "/", do: send_resp(conn, 200, "")
 
-  get "/shape/:shape_definition", to: Electric.Plug.ServeShapePlug
-  delete "/shape/:shape_definition", to: Electric.Plug.DeleteShapePlug
+  get "/shape/:root_table", to: Electric.Plug.ServeShapePlug
+  delete "/shape/:root_table", to: Electric.Plug.DeleteShapePlug
 
   match _ do
     send_resp(conn, 404, "Not found")


### PR DESCRIPTION
#18 caused a regression, where using the actual HTTP API from any client failed on a missing param:

```
07:20:37.291 [error] ** (Plug.Conn.WrapperError) ** (KeyError) key :root_table not found in: %{offset: -1}
    (ecto 3.11.2) lib/ecto/changeset.ex:1782: Ecto.Changeset.fetch_change!/2
    (electric 0.1.0) lib/electric/plug/serve_shape_plug.ex:44: Electric.Plug.ServeShapePlug.Params.cast_root_table/2
    (electric 0.1.0) lib/electric/plug/serve_shape_plug.ex:27: Electric.Plug.ServeShapePlug.Params.validate/2
    (electric 0.1.0) lib/electric/plug/delete_shape_plug.ex:32: Electric.Plug.DeleteShapePlug.validate_query_params/2
    (electric 0.1.0) lib/electric/plug/delete_shape_plug.ex:1: Electric.Plug.DeleteShapePlug.plug_builder_call/2
    (electric 0.1.0) deps/plug/lib/plug/router.ex:246: anonymous fn/4 in Electric.Plug.Router.dispatch/2
    (telemetry 1.2.1) /Users/thruflo/Development/electric-sql/electric-next/sync_service/deps/telemetry/src/telemetry.erl:321: :telemetry.span/3
    (electric 0.1.0) deps/plug/lib/plug/router.ex:242: Electric.Plug.Router.dispatch/2
```

This renames the parameter in the router to match what's now expected by the code.

I'd suggest that #18 should not have been merged without running the client tests and that the elixir code should have some tests that actually use the HTTP API.