### PR TITLE
Fixes to get browser/client working

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -145,7 +145,7 @@ export class ShapeStream {
 
       if (this.shapeId) {
         // This should probably be a header for better cache breaking?
-        url.searchParams.set(`shapeId`, this.shapeId!)
+        url.searchParams.set(`shape_id`, this.shapeId!)
       }
 
       console.log({
@@ -160,7 +160,10 @@ export class ShapeStream {
             }
 
             const { headers, status } = response
-            this.shapeId = headers.get(`x-electric-shape-id`) ?? undefined
+            const shapeId = headers.get(`X-Electric-Shape-Id`) ?? undefined
+            if (shapeId) {
+              this.shapeId = shapeId
+            }
 
             attempt = 0
 

--- a/sync_service/lib/electric/plug/serve_shape_plug.ex
+++ b/sync_service/lib/electric/plug/serve_shape_plug.ex
@@ -201,8 +201,8 @@ defmodule Electric.Plug.ServeShapePlug do
   def cors(conn, _opts) do
     conn
     |> Plug.Conn.put_resp_header("access-control-allow-origin", "*")
+    |> Plug.Conn.put_resp_header("access-control-expose-headers", "*")
     |> Plug.Conn.put_resp_header("access-control-allow-methods", "GET, POST, OPTIONS")
-    |> Plug.Conn.put_resp_header("access-control-allow-headers", "content-type, authorization")
   end
 
   @up_to_date [%{headers: %{control: "up-to-date"}}]


### PR DESCRIPTION
- browsers don't get access to headers without `access-control-expose-headers: *` set so browsers weren't picking up x-electric-shape-id — we could narrow this and pick specific headers to expose if we'd like
- query argument changed from `shapeId` to `shape_id`