### PR TITLE
Encapsulate shape cache storage behind shape cache

### DIFF
--- a/sync_service/lib/electric/application.ex
+++ b/sync_service/lib/electric/application.ex
@@ -13,6 +13,7 @@ defmodule Electric.Application do
 
     with {:ok, storage_opts} <- storage_module.shared_opts(init_params) do
       storage = {storage_module, storage_opts}
+      shape_cache = {Electric.ShapeCache, storage: storage}
 
       children =
         if Application.fetch_env!(:electric, :environment) != :test do
@@ -21,9 +22,9 @@ defmodule Electric.Application do
             {storage_module, storage_opts},
             {Registry,
              name: Registry.ShapeChanges, keys: :duplicate, partitions: System.schedulers_online()},
-            {Electric.ShapeCache, storage: storage},
+            shape_cache,
             {Electric.Replication.ShapeLogStorage,
-             storage: storage, registry: Registry.ShapeChanges},
+             registry: Registry.ShapeChanges, shape_cache: shape_cache},
             {Postgrex,
              Application.fetch_env!(:electric, :database_config) ++
                [

--- a/sync_service/test/electric/replication/shape_log_storage_test.exs
+++ b/sync_service/test/electric/replication/shape_log_storage_test.exs
@@ -25,7 +25,6 @@ defmodule Electric.Replication.ShapeLogStorageTest do
     # Start the ShapeLogStorage process
     opts = [
       name: :test_shape_log_storage,
-      storage: {MockStorage, []},
       registry: registry_name,
       shape_cache: {MockShapeCache, []}
     ]
@@ -41,14 +40,9 @@ defmodule Electric.Replication.ShapeLogStorageTest do
       xmin = 100
       xid = 150
       lsn = Lsn.from_string("0/10")
-      number_lsn = Lsn.to_integer(lsn)
 
       MockShapeCache
       |> expect(:list_active_shapes, 2, fn _ -> [{shape_id, shape, xmin}] end)
-      |> expect(:update_shape_latest_offset, 2, fn ^shape_id, ^number_lsn, _ -> :ok end)
-      |> allow(self(), server)
-
-      MockStorage
       |> expect(:append_to_log!, fn ^shape_id, ^lsn, ^xmin, _, _ -> :ok end)
       |> expect(:append_to_log!, fn ^shape_id, ^lsn, ^xid, _, _ -> :ok end)
       |> allow(self(), server)
@@ -143,14 +137,9 @@ defmodule Electric.Replication.ShapeLogStorageTest do
       xmin = 100
       xid = 150
       lsn = Lsn.from_string("0/10")
-      number_lsn = Lsn.to_integer(lsn)
 
       MockShapeCache
       |> expect(:list_active_shapes, fn _ -> [{shape_id, shape, xmin}] end)
-      |> expect(:update_shape_latest_offset, fn ^shape_id, ^number_lsn, _ -> :ok end)
-      |> allow(self(), server)
-
-      MockStorage
       |> expect(:append_to_log!, fn ^shape_id, ^lsn, ^xid, _, _ -> :ok end)
       |> allow(self(), server)
 
@@ -173,7 +162,6 @@ defmodule Electric.Replication.ShapeLogStorageTest do
       xmin = 100
       xid = 150
       lsn = Lsn.from_string("0/10")
-      number_lsn = Lsn.to_integer(lsn)
 
       MockShapeCache
       |> expect(:list_active_shapes, fn _ ->
@@ -182,11 +170,6 @@ defmodule Electric.Replication.ShapeLogStorageTest do
           {shape2, %Shape{root_table: {"public", "other_table"}}, xmin}
         ]
       end)
-      |> expect(:update_shape_latest_offset, fn ^shape1, ^number_lsn, _ -> :ok end)
-      |> expect(:update_shape_latest_offset, fn ^shape2, ^number_lsn, _ -> :ok end)
-      |> allow(self(), server)
-
-      MockStorage
       |> expect(:append_to_log!, fn ^shape1, ^lsn, ^xid, [change], _ ->
         assert change.record["id"] == "1"
         :ok

--- a/sync_service/test/electric/shape_cache_test.exs
+++ b/sync_service/test/electric/shape_cache_test.exs
@@ -120,7 +120,15 @@ defmodule Electric.ShapeCacheTest do
       assert {^shape_id, offset_after_snapshot} = ShapeCache.get_or_create_shape_id(shape, opts)
 
       expected_offset_after_log_entry = 1000
-      :ok = ShapeCache.update_shape_latest_offset(shape_id, expected_offset_after_log_entry, opts)
+
+      :ok =
+        ShapeCache.append_to_log!(
+          shape_id,
+          Lsn.from_integer(expected_offset_after_log_entry),
+          _xid = 0,
+          _changes = [],
+          opts
+        )
 
       assert {^shape_id, offset_after_log_entry} = ShapeCache.get_or_create_shape_id(shape, opts)
 
@@ -128,10 +136,6 @@ defmodule Electric.ShapeCacheTest do
       assert initial_offset == offset_after_snapshot
       assert offset_after_log_entry > offset_after_snapshot
       assert offset_after_log_entry == expected_offset_after_log_entry
-    end
-
-    test "fails to update latest offset if shape doesn't exist", %{shape_cache_opts: opts} do
-      assert :error = ShapeCache.update_shape_latest_offset("foo", 10, opts)
     end
 
     test "correctly propagates the error", %{shape_cache_opts: opts} do

--- a/sync_service/test/support/component_setup.ex
+++ b/sync_service/test/support/component_setup.ex
@@ -30,7 +30,8 @@ defmodule Support.ComponentSetup do
     %{
       shape_cache_opts: [
         server: :"shape_cache_#{ctx.test}",
-        shape_meta_table: shape_meta_table
+        shape_meta_table: shape_meta_table,
+        storage: ctx.storage
       ]
     }
   end


### PR DESCRIPTION
The shape cache storage seems to me to be an implementation detail of the shape cache so should be encapsulated by the shape cache.

My initial motivation was caused by the `update_shape_latest_offset` which could be called independently from `append_to_log!` meaning that the latest offset could deviate from the latest offset in the log, which surprised me when writing latest_offset recovery. They were kept in sync by `ShapeLogStorage` whereas now ShapeCache keeps them in sync itself, and the fact it caches the latest_offset in ETS is just an implantation detail.  