### PR TITLE
feat(sync-service): use a persisted, named slot to be able to restart replication from the last acknowledged LSN

### DIFF
--- a/.changeset/tender-swans-bake.md
+++ b/.changeset/tender-swans-bake.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Use a persistent replication slot to maintain replication connection state between Electric/Postgres restarts.

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -8,6 +8,7 @@ defmodule Electric.Application do
     {storage_module, init_params} = Application.fetch_env!(:electric, :storage)
 
     publication_name = "electric_publication"
+    slot_name = "electric_slot"
 
     with {:ok, storage_opts} <- storage_module.shared_opts(init_params) do
       storage = {storage_module, storage_opts}
@@ -36,6 +37,7 @@ defmodule Electric.Application do
              replication_opts: [
                publication_name: publication_name,
                try_creating_publication?: true,
+               slot_name: slot_name,
                transaction_received:
                  {Electric.Replication.ShapeLogCollector, :store_transaction, []}
              ],

--- a/packages/sync-service/lib/electric/application.ex
+++ b/packages/sync-service/lib/electric/application.ex
@@ -43,7 +43,8 @@ defmodule Electric.Application do
              ],
              pool_opts: [
                name: Electric.DbPool,
-               pool_size: 10
+               pool_size: 10,
+               types: PgInterop.Postgrex.Types
              ]},
             {Electric.Postgres.Inspector.EtsInspector, pool: Electric.DbPool},
             {Bandit,

--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -1,11 +1,13 @@
 defmodule Electric.Postgres.ReplicationClient do
   @moduledoc """
-  A client module for Postgres logical replication
+  A client module for Postgres logical replication.
   """
+  use Postgrex.ReplicationConnection
+
   alias Electric.Postgres.ReplicationClient.Collector
   alias Electric.Postgres.LogicalReplication.Decoder
+
   require Logger
-  use Postgrex.ReplicationConnection
 
   defmodule State do
     @enforce_keys [:transaction_received, :publication_name]
@@ -14,10 +16,19 @@ defmodule Electric.Postgres.ReplicationClient do
       :publication_name,
       :try_creating_publication?,
       :start_streaming?,
+      :slot_name,
       :display_settings,
       origin: "postgres",
       txn_collector: %Collector{},
-      step: :disconnected
+      step: :disconnected,
+      # Keep track of the latest received and applied WAL offsets so that we can report them
+      # back to Postgres in standby status update messages.
+      #
+      # Postgres defines separate "flushed" and "applied" offsets but we merge those into one
+      # concept of "applied WAL" which is defined as the offset we have successfully processed
+      # and persisted in our shape log storage.
+      received_wal: 0,
+      applied_wal: 0
     ]
 
     @type t() :: %__MODULE__{
@@ -25,6 +36,7 @@ defmodule Electric.Postgres.ReplicationClient do
             publication_name: String.t(),
             try_creating_publication?: boolean(),
             start_streaming?: boolean(),
+            slot_name: String.t(),
             origin: String.t(),
             txn_collector: Collector.t(),
             step:
@@ -34,14 +46,17 @@ defmodule Electric.Postgres.ReplicationClient do
               | :ready_to_stream
               | :streaming
               | :set_display_setting,
-            display_settings: [String.t()]
+            display_settings: [String.t()],
+            received_wal: non_neg_integer,
+            applied_wal: non_neg_integer
           }
 
     @opts_schema NimbleOptions.new!(
                    transaction_received: [required: true, type: :mfa],
                    publication_name: [required: true, type: :string],
-                   try_creating_publication?: [type: :boolean, required: true],
-                   start_streaming?: [type: :boolean, default: true]
+                   try_creating_publication?: [required: true, type: :boolean],
+                   start_streaming?: [type: :boolean, default: true],
+                   slot_name: [required: true, type: :string]
                  )
 
     @spec new(Access.t()) :: t()
@@ -52,6 +67,10 @@ defmodule Electric.Postgres.ReplicationClient do
       struct!(__MODULE__, opts)
     end
   end
+
+  @repl_msg_x_log_data ?w
+  @repl_msg_primary_keepalive ?k
+  @repl_msg_standby_status_update ?r
 
   def start_link(connection_opts, replication_opts) do
     Postgrex.ReplicationConnection.start_link(__MODULE__, replication_opts, connection_opts)
@@ -107,7 +126,9 @@ defmodule Electric.Postgres.ReplicationClient do
     end
   end
 
-  def handle_result([_result], %State{step: :create_slot} = state) do
+  def handle_result([result], %State{step: :create_slot} = state) do
+    log_slot_creation_result(result)
+
     if state.start_streaming? do
       start_streaming_step(state)
     else
@@ -129,9 +150,13 @@ defmodule Electric.Postgres.ReplicationClient do
   @spec handle_data(binary(), State.t()) ::
           {:noreply, State.t()} | {:noreply, list(binary()), State.t()}
   def handle_data(
-        <<?w, _wal_start::64, _wal_end::64, _clock::64, rest::binary>>,
+        <<@repl_msg_x_log_data, wal_start::64, wal_end::64, _clock::64, rest::binary>>,
         %State{} = state
       ) do
+    Logger.debug("XLogData: wal_start=#{wal_start}, wal_end=#{wal_end}")
+
+    state = update_received_wal(state, wal_end)
+
     rest
     |> Decoder.decode()
     |> Collector.handle_message(state.txn_collector)
@@ -140,20 +165,51 @@ defmodule Electric.Postgres.ReplicationClient do
         {:noreply, %{state | txn_collector: txn_collector}}
 
       {txn, %Collector{} = txn_collector} ->
+        state = %{state | txn_collector: txn_collector}
+
         {m, f, args} = state.transaction_received
-        apply(m, f, [txn | args])
-        {:noreply, %{state | txn_collector: txn_collector}}
+
+        case apply(m, f, [txn | args]) do
+          :ok ->
+            state = update_applied_wal(state, wal_end)
+            {:noreply, [encode_standby_status_update(state)], state}
+
+          _ ->
+            {:noreply, state}
+        end
     end
   end
 
-  def handle_data(<<?k, wal_end::64, _clock::64, reply>>, state) do
+  def handle_data(<<@repl_msg_primary_keepalive, wal_end::64, _clock::64, reply>>, state) do
+    state = update_received_wal(state, wal_end)
+
     messages =
       case reply do
-        1 -> [<<?r, wal_end + 1::64, wal_end + 1::64, wal_end + 1::64, current_time()::64, 0>>]
+        1 -> [encode_standby_status_update(state)]
         0 -> []
       end
 
     {:noreply, messages, state}
+  end
+
+  defp encode_standby_status_update(state) do
+    # Even though Postgres docs say[1] that these values need to be incremented by 1,
+    # Postgres' own walreceiver process does not seem to be doing that.
+    # Given the fact that `state.applied_wal` is set to the `wal_end` value of the most
+    # recently processed XLogData message (which itself appears to be the end LSN + 1 of the last
+    # transaction's Commit message) I'm worried about Postgres skipping the next transaction by
+    # treating the "flushed LSN" we're reporting back to it as having passed the transaction.
+    # TODO: needs more testing/PG source reading/whatever.
+    #
+    # [1]: https://www.postgresql.org/docs/current/protocol-replication.html#PROTOCOL-REPLICATION-STANDBY-STATUS-UPDATE
+    <<
+      @repl_msg_standby_status_update,
+      state.received_wal::64,
+      state.applied_wal::64,
+      state.applied_wal::64,
+      current_time()::64,
+      0
+    >>
   end
 
   @epoch DateTime.to_unix(~U[2000-01-01 00:00:00Z], :microsecond)
@@ -166,16 +222,42 @@ defmodule Electric.Postgres.ReplicationClient do
   end
 
   defp create_replication_slot_step(state) do
-    query = "CREATE_REPLICATION_SLOT electric TEMPORARY LOGICAL pgoutput NOEXPORT_SNAPSHOT"
+    query = "CREATE_REPLICATION_SLOT #{state.slot_name} LOGICAL pgoutput NOEXPORT_SNAPSHOT"
     {:query, query, %{state | step: :create_slot}}
   end
 
   defp start_streaming_step(state) do
     query =
-      "START_REPLICATION SLOT electric LOGICAL 0/0 (proto_version '1', publication_names '#{state.publication_name}')"
+      "START_REPLICATION SLOT #{state.slot_name} LOGICAL 0/0 (proto_version '1', publication_names '#{state.publication_name}')"
 
     Logger.info("Started replication from postgres")
 
     {:stream, query, [], %{state | step: :streaming}}
   end
+
+  defp log_slot_creation_result(result) do
+    Logger.debug(fn ->
+      %Postgrex.Result{
+        command: :create,
+        columns: ["slot_name", "consistent_point", "snapshot_name", "output_plugin"],
+        rows: [[_, lsn_str, nil, _]],
+        num_rows: 1,
+        connection_id: _,
+        messages: []
+      } = result
+
+      "Created new slot at lsn=#{lsn_str}"
+    end)
+  end
+
+  defp update_received_wal(state, wal) when wal > state.received_wal,
+    do: %{state | received_wal: wal}
+
+  defp update_received_wal(%{received_wal: wal} = state, wal), do: state
+  defp update_received_wal(state, 0), do: state
+
+  defp update_applied_wal(state, wal) when wal > state.applied_wal,
+    do: %{state | applied_wal: wal}
+
+  defp update_applied_wal(state, 0), do: state
 end

--- a/packages/sync-service/lib/pg_interop/postgrex/extensions/pg_lsn.ex
+++ b/packages/sync-service/lib/pg_interop/postgrex/extensions/pg_lsn.ex
@@ -1,0 +1,22 @@
+defmodule PgInterop.Postgrex.Extensions.PgLsn do
+  use Postgrex.BinaryExtension, send: "pg_lsn_send"
+  import Postgrex.BinaryUtils, warn: false
+
+  def encode(_state) do
+    quote location: :keep do
+      %Electric.Postgres.Lsn{} = lsn ->
+        <<8::int32(), Electric.Postgres.Lsn.to_integer(lsn)::uint64()>>
+
+      other ->
+        raise DBConnection.EncodeError,
+              Postgrex.Utils.encode_msg(other, "a value of type Electric.Postgres.Lsn.t()")
+    end
+  end
+
+  def decode(_) do
+    quote location: :keep do
+      <<8::int32(), wal_offset::uint64()>> ->
+        Electric.Postgres.Lsn.from_integer(wal_offset)
+    end
+  end
+end

--- a/packages/sync-service/lib/pg_interop/postgrex/types.ex
+++ b/packages/sync-service/lib/pg_interop/postgrex/types.ex
@@ -1,0 +1,1 @@
+Postgrex.Types.define(PgInterop.Postgrex.Types, [PgInterop.Postgrex.Extensions.PgLsn])

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -36,7 +36,9 @@ defmodule Electric.Plug.RouterTest do
     setup {DbStructureSetup, :with_basic_tables}
     setup {DbStructureSetup, :with_sql_execute}
 
-    setup(do: %{publication_name: "electric_test_pub"})
+    setup do
+      %{publication_name: "electric_test_publication", slot_name: "electric_test_slot"}
+    end
 
     setup :with_complete_stack
 

--- a/packages/sync-service/test/electric/postgres/replication_client/collector_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client/collector_test.exs
@@ -238,7 +238,7 @@ defmodule Electric.Postgres.ReplicationClient.CollectorTest do
 
     {completed_txn, updated_collector} = Collector.handle_message(commit_msg, collector)
 
-    assert %Transaction{xid: 456, lsn: @test_lsn, last_log_offset: @test_log_offset} =
+    assert %Transaction{xid: 456, lsn: @test_end_lsn, last_log_offset: @test_log_offset} =
              completed_txn
 
     assert %Collector{transaction: nil, tx_op_index: nil} = updated_collector

--- a/packages/sync-service/test/pg_interop/postgrex/extensions/pg_lsn_test.exs
+++ b/packages/sync-service/test/pg_interop/postgrex/extensions/pg_lsn_test.exs
@@ -1,0 +1,38 @@
+defmodule PgInterop.Postgrex.Extensions.PgLsnTest do
+  use ExUnit.Case, async: true
+
+  alias Electric.Postgres.Lsn
+
+  setup {Support.DbSetup, :with_unique_db}
+
+  test "can decode pg_lsn values", %{db_conn: conn} do
+    {:ok, result} = Postgrex.query(conn, "SELECT '0/0'::pg_lsn", [])
+    assert %Postgrex.Result{rows: [[lsn]], num_rows: 1} = result
+    assert Lsn.from_string("0/0") == lsn
+
+    {:ok, result} = Postgrex.query(conn, "SELECT '2BDC54/6291F4B1'::pg_lsn", [])
+    assert %Postgrex.Result{rows: [[lsn]], num_rows: 1} = result
+    assert Lsn.from_integer(12_34_56_78_9_87_65_43_21) == lsn
+  end
+
+  test "can encode pg_lsn values", %{db_conn: conn} do
+    lsn1 = Lsn.from_string("1/0")
+    lsn2 = Lsn.from_string("0/0")
+    {:ok, result} = Postgrex.query(conn, "SELECT $1::pg_lsn - $2", [lsn1, lsn2])
+    assert %Postgrex.Result{rows: [[lsn_diff]], num_rows: 1} = result
+    assert :math.pow(2, 32) == Decimal.to_float(lsn_diff)
+  end
+
+  test "raises on invalid values", %{db_conn: conn} do
+    for val <- [4445, "0/0", Decimal.new("12345")] do
+      error_msg =
+        "Postgrex expected a value of type Electric.Postgres.Lsn.t(), got #{inspect(val)}. " <>
+          "Please make sure the value you are passing matches the definition in your table " <>
+          "or in your query or convert the value accordingly."
+
+      assert_raise DBConnection.EncodeError, error_msg, fn ->
+        Postgrex.query(conn, "SELECT $1::pg_lsn", [val])
+      end
+    end
+  end
+end

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -83,9 +83,10 @@ defmodule Support.ComponentSetup do
   def with_replication_client(ctx) do
     replication_opts = [
       publication_name: ctx.publication_name,
+      try_creating_publication?: true,
+      slot_name: ctx.slot_name,
       transaction_received:
-        {Electric.Replication.ShapeLogCollector, :store_transaction, [ctx.shape_log_collector]},
-      try_creating_publication?: true
+        {Electric.Replication.ShapeLogCollector, :store_transaction, [ctx.shape_log_collector]}
     ]
 
     {:ok, pid} = ReplicationClient.start_link(ctx.db_config, replication_opts)

--- a/packages/sync-service/test/test_helper.exs
+++ b/packages/sync-service/test/test_helper.exs
@@ -1,3 +1,4 @@
 Mox.defmock(Electric.ShapeCache.MockStorage, for: Electric.ShapeCache.Storage)
 Mox.defmock(Electric.ShapeCacheMock, for: Electric.ShapeCacheBehaviour)
-ExUnit.start()
+
+ExUnit.start(assert_receive_timeout: 400)


### PR DESCRIPTION
Changes introduced in this PR:
- `Electric.Postgres.ReplicationClient` creates a persistent replication slot on first connection to Postgres and reuses it for all subsequent connections.
- The replication slot is advanced forward after every incoming transaction is processed by our shape logs. In practice, Postgres can keep the slot's LSN unchanged for some time until it decides to garbage-collect older WAL records.
- Postgrex extension for the Postgres type `pg_type`
- Ensure that if a transaction processing is interrupted, the same transaction will be processed again when Electric restarts

Additional work on replication slot reliability is done in https://github.com/electric-sql/electric-next/pull/106.