### PR TITLE
Increase max stacktrace depth to 50

### DIFF
--- a/sync_service/lib/electric/application.ex
+++ b/sync_service/lib/electric/application.ex
@@ -9,6 +9,8 @@ defmodule Electric.Application do
 
   @impl true
   def start(_type, _args) do
+    :erlang.system_flag(:backtrace_depth, 50)
+
     {storage_module, init_params} = Application.fetch_env!(:electric, :storage)
 
     with {:ok, storage_opts} <- storage_module.shared_opts(init_params) do


### PR DESCRIPTION
The default maximum stacktrace depth is 8, which can lead to some unhelpful stack traces that don't show where the problem originated, such as the one @KyleAMathews found:
<img width="1477" alt="Screenshot 2024-07-12 at 09 11 13" src="https://github.com/user-attachments/assets/e435e39d-f38c-4b86-8926-f712bd389ff8">

This PR increases the maximum to 50. I've done this one most of the Elixir projects I've worked on. The only downsides I've noticed are that logs can be a little larger and some errors take up more of your screen while debugging, but this seems a small price to pay for the increased diagnostic ability.