### PR TITLE
Rename ShapeLogStorage to ShapeLogCollector

### DIFF
--- a/sync_service/lib/electric/application.ex
+++ b/sync_service/lib/electric/application.ex
@@ -31,7 +31,7 @@ defmodule Electric.Application do
             {Registry,
              name: Registry.ShapeChanges, keys: :duplicate, partitions: System.schedulers_online()},
             shape_cache,
-            {Electric.Replication.ShapeLogStorage,
+            {Electric.Replication.ShapeLogCollector,
              registry: Registry.ShapeChanges, shape_cache: shape_cache},
             {Postgrex,
              Application.fetch_env!(:electric, :database_config) ++
@@ -45,7 +45,7 @@ defmodule Electric.Application do
                  init_opts: [
                    publication_name: publication_name,
                    transaction_received:
-                     {Electric.Replication.ShapeLogStorage, :store_transaction, []},
+                     {Electric.Replication.ShapeLogCollector, :store_transaction, []},
                    try_creating_publication?: true
                  ]
                ]},

--- a/sync_service/lib/electric/replication/shape_log_collector.ex
+++ b/sync_service/lib/electric/replication/shape_log_collector.ex
@@ -1,4 +1,4 @@
-defmodule Electric.Replication.ShapeLogStorage do
+defmodule Electric.Replication.ShapeLogCollector do
   @moduledoc """
   When any txn comes from postgres, we need to store it into the
   log for this shape if and only if it has txid >= xmin of the snapshot.

--- a/sync_service/test/electric/replication/shape_log_collector_test.exs
+++ b/sync_service/test/electric/replication/shape_log_collector_test.exs
@@ -1,11 +1,11 @@
-defmodule Electric.Replication.ShapeLogStorageTest do
+defmodule Electric.Replication.ShapeLogCollectorTest do
   use ExUnit.Case, async: true
   import Mox
 
   alias Electric.Replication.Eval.Parser
   alias Electric.Shapes.Shape
   alias Electric.Postgres.Lsn
-  alias Electric.Replication.ShapeLogStorage
+  alias Electric.Replication.ShapeLogCollector
   alias Electric.Replication.Changes.Transaction
   alias Electric.Replication.Changes
   alias Electric.Replication.LogOffset
@@ -23,14 +23,14 @@ defmodule Electric.Replication.ShapeLogStorageTest do
     registry_name = Module.concat(__MODULE__, Registry)
     start_link_supervised!({Registry, keys: :duplicate, name: registry_name})
 
-    # Start the ShapeLogStorage process
+    # Start the ShapeLogCollector process
     opts = [
       name: :test_shape_log_storage,
       registry: registry_name,
       shape_cache: {MockShapeCache, []}
     ]
 
-    {:ok, pid} = start_supervised({ShapeLogStorage, opts})
+    {:ok, pid} = start_supervised({ShapeLogCollector, opts})
     %{server: pid, registry: registry_name}
   end
 
@@ -56,7 +56,7 @@ defmodule Electric.Replication.ShapeLogStorageTest do
         last_log_offset: last_log_offset
       }
 
-      assert :ok = ShapeLogStorage.store_transaction(txn, server)
+      assert :ok = ShapeLogCollector.store_transaction(txn, server)
 
       txn = %Transaction{
         xid: xid,
@@ -65,7 +65,7 @@ defmodule Electric.Replication.ShapeLogStorageTest do
         last_log_offset: last_log_offset
       }
 
-      assert :ok = ShapeLogStorage.store_transaction(txn, server)
+      assert :ok = ShapeLogCollector.store_transaction(txn, server)
     end
 
     test "doesn't append to log when xid < xmin", %{server: server} do
@@ -87,7 +87,7 @@ defmodule Electric.Replication.ShapeLogStorageTest do
         last_log_offset: last_log_offset
       }
 
-      assert :ok = ShapeLogStorage.store_transaction(txn, server)
+      assert :ok = ShapeLogCollector.store_transaction(txn, server)
     end
 
     test "doesn't append to log when change is irrelevant for active shapes", %{server: server} do
@@ -114,7 +114,7 @@ defmodule Electric.Replication.ShapeLogStorageTest do
         last_log_offset: last_log_offset
       }
 
-      assert :ok = ShapeLogStorage.store_transaction(txn, server)
+      assert :ok = ShapeLogCollector.store_transaction(txn, server)
     end
 
     test "handles truncate without appending to log", %{server: server} do
@@ -138,7 +138,7 @@ defmodule Electric.Replication.ShapeLogStorageTest do
         last_log_offset: last_log_offset
       }
 
-      assert :ok = ShapeLogStorage.store_transaction(txn, server)
+      assert :ok = ShapeLogCollector.store_transaction(txn, server)
     end
 
     test "notifies listeners of new changes", %{server: server, registry: registry} do
@@ -164,7 +164,7 @@ defmodule Electric.Replication.ShapeLogStorageTest do
         last_log_offset: last_log_offset
       }
 
-      assert :ok = ShapeLogStorage.store_transaction(txn, server)
+      assert :ok = ShapeLogCollector.store_transaction(txn, server)
       assert_receive {^ref, :new_changes, ^last_log_offset}, 1000
     end
 
@@ -204,7 +204,7 @@ defmodule Electric.Replication.ShapeLogStorageTest do
         last_log_offset: last_log_offset
       }
 
-      assert :ok = ShapeLogStorage.store_transaction(txn, server)
+      assert :ok = ShapeLogCollector.store_transaction(txn, server)
     end
   end
 end


### PR DESCRIPTION
ShapeLogStorage doesn't actually store the ShapeLog, the ShapeCache.Storage does, really it just collects the log so this PR changes it's name to reflect that.