### PR TITLE
Fix live mode to return changes

### DIFF
--- a/sync_service/lib/electric/replication/shape_log_storage.ex
+++ b/sync_service/lib/electric/replication/shape_log_storage.ex
@@ -75,14 +75,14 @@ defmodule Electric.Replication.ShapeLogStorage do
     {:reply, :ok, state}
   end
 
-  defp notify_listeners(registry, :new_changes, shape_id, changes) do
+  defp notify_listeners(registry, :new_changes, shape_id, lsn) do
     Registry.dispatch(registry, shape_id, fn registered ->
       Logger.debug(fn ->
         "Notifying ~#{length(registered)} clients about new changes to #{shape_id}"
       end)
 
       for {pid, ref} <- registered,
-          do: send(pid, {ref, :new_changes, changes})
+          do: send(pid, {ref, :new_changes, lsn})
     end)
   end
 end


### PR DESCRIPTION
### Problem

Live mode is broken in latest main.

### Scenario to reproduce

- Client is up to date
- Makes HTTP request in live mode
- There is nothing to serve so the sync service hangs the client until there is an update
- Then we insert a row in PG
- Client gets an up-to-date answer that does not contain the inserted row!

### The cause

- When we detect a new change, we call `serve_log_or_snapshot` which requests the log from the provided offset until `last_offset`. The latter is assigned when the request comes in and we load the shape info. However, at that time, the client is up to date so the last_offset is the same offset is the offset provided by the client. So, when there is a new update and we call `serve_log_or_snapshot` we’re actually not asking for the log till the end but only till where the client has already seen…
- For the same reason, the `x-electric-chunk-last-offset` chunk header is wrong as it contains the old latest offset.  

### How come we missed this

This was not caught by our current tests because our test was wrong as it creates a shape with latest offset 100 and then simulates a live update coming in with offset 70. The offset of the incoming change must be bigger than the current latest offset. After changing it such that the incoming change has offset 120, it started failing.

### Proposed Fix
This PR fixes the problem by not providing an upper bound when calling `get_log_stream`, by default when the upper bound is not provided it uses `:infinity` and thus won't miss any updates.

To fix the issue with the `x-electric-chunk-last-offset` header i modified `serve_log_or_snapshot` to fetch the offset of the latest change in the log that we are about to serve and use it to update the header. I'm not sure if `List.last` is a performance issue here:

```elixir
log =
  Shapes.get_log_stream(conn.assigns.config, shape_id, since: offset)
  |> Enum.to_list()
last_offset = List.last(log)
```

Since we're already doing `to_list` maybe it's not a performance problem (if internally Elixir is lazy then it might be doing only a single pass and be just fine).

I also modified the existing unit test for live queries in the shape plug to check the header and fix the offsets.
