### PR TITLE
Update pnpm-lock.yaml after running `pnpm install`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,6 +437,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2(@types/node@20.14.11)(jsdom@24.1.0)
 
+  packages/sync-service: {}
+
   packages/typescript-client:
     optionalDependencies:
       '@rollup/rollup-darwin-arm64':


### PR DESCRIPTION
My lock file got this change after I ran `pnpm install` for the first time. I thought it should be committed to the repo.