### PR TITLE
Fix caching of Elixir deps and builds on CI

### DIFF
--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: packages/sync-service/deps
-          key: ${{ runner.os }}-mix-${{ hashFiles('sync-service/**/mix.lock') }}
+          key: ${{ runner.os }}-mix-${{ hashFiles('packages/sync-service/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-
       - name: Restore compiled code
         uses: actions/cache/restore@v4
@@ -51,7 +51,7 @@ jobs:
           path: |
             packages/sync-service/_build/*/lib
             !packages/sync-service/_build/*/lib/electric
-          key: ${{ runner.os }}-build-${{ hashFiles('sync-service/**/mix.lock') }}
+          key: ${{ runner.os }}-build-${{ hashFiles('packages/sync-service/mix.lock') }}
       - name: Install dependencies
         run: mix deps.get && mix deps.compile
       - name: Save compiled code
@@ -60,7 +60,7 @@ jobs:
           path: |
             packages/sync-service/_build/*/lib
             !packages/sync-service/_build/*/lib/electric
-          key: ${{ runner.os }}-build-${{ hashFiles('sync-service/**/mix.lock') }}
+          key: ${{ runner.os }}-build-${{ hashFiles('packages/sync-service/mix.lock') }}
       - name: Compiles without warnings
         run: mix compile --force --all-warnings --warnings-as-errors
       - name: Run tests
@@ -81,7 +81,7 @@ jobs:
         id: cache-deps
         uses: actions/cache@v4
         with:
-          path: sync-service/deps
-          key: ${{ runner.os }}-mixdeps-${{ hashFiles('sync-service/**/mix.lock') }}
+          path: packages/sync-service/deps
+          key: ${{ runner.os }}-mixdeps-${{ hashFiles('packages/sync-service/mix.lock') }}
       - run: mix deps.get
       - run: mix format --check-formatted

--- a/.github/workflows/ts_test.yml
+++ b/.github/workflows/ts_test.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: packages/sync-service/deps
-          key: ${{ runner.os }}-mix-${{ hashFiles('sync-service/**/mix.lock') }}
+          key: ${{ runner.os }}-mix-${{ hashFiles('packages/sync-service/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-
       - name: Restore compiled code
         uses: actions/cache@v4
@@ -41,7 +41,7 @@ jobs:
           path: |
             packages/sync-service/_build/*/lib
             !packages/sync-service/_build/*/lib/electric
-          key: ${{ runner.os }}-build-dev-${{ hashFiles('sync-service/**/mix.lock') }}
+          key: ${{ runner.os }}-build-${{ hashFiles('packages/sync-service/mix.lock') }}
       - name: Install dependencies
         run: mix deps.get && mix deps.compile
         working-directory: packages/sync-service


### PR DESCRIPTION
Cache keys were using incorrect paths to the `sync-service/mix.lock` file.