### PR TITLE
Experimental updates to toastable columns

### DIFF
--- a/packages/sync-service/lib/electric/postgres/replication_client.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client.ex
@@ -95,6 +95,7 @@ defmodule Electric.Postgres.ReplicationClient do
       ) do
     rest
     |> Decoder.decode()
+    |> IO.inspect()
     |> Collector.handle_message(state.txn_collector)
     |> case do
       %Collector{} = txn_collector ->

--- a/packages/sync-service/lib/m.ex
+++ b/packages/sync-service/lib/m.ex
@@ -1,0 +1,94 @@
+defmodule M do
+  def prepare(conn) do
+    Postgrex.query!(
+      conn,
+      """
+      CREATE TABLE IF NOT EXISTS items2 (
+        id UUID PRIMARY KEY,
+        val1 TEXT,
+        val2 TEXT,
+        index int
+      )
+      """,
+      []
+    )
+
+    Postgrex.query!(
+      conn,
+      """
+      ALTER TABLE items2 REPLICA IDENTITY FULL
+      """,
+      []
+    )
+
+    Postgrex.query!(
+      conn,
+      """
+      ALTER PUBLICATION electric_publication ADD TABLE items2
+      """,
+      []
+    )
+  end
+
+  def insert(conn) do
+    val1 =
+      Stream.repeatedly(fn -> :rand.uniform(125 - 32) + 32 end)
+      |> Enum.take(4000)
+
+    val2 = Enum.shuffle(val1)
+
+    Postgrex.query!(
+      conn,
+      """
+      INSERT INTO
+        items2 (id, val1, val2)
+      VALUES
+        (gen_random_uuid(), $1, $2)
+      """,
+      [List.to_string(val1), List.to_string(val2)]
+    )
+  end
+
+  def update(conn, id, kw) do
+    {:ok, uuid} = Ecto.UUID.dump(id)
+
+    {assignments, vals} =
+      kw
+      |> Stream.with_index(2)
+      |> Enum.map(fn {{k, v}, i} ->
+        {"#{k} = $#{i}", v}
+      end)
+      |> Enum.unzip()
+
+    vals =
+      Enum.map(vals, fn
+        :small ->
+          Stream.repeatedly(fn -> :rand.uniform(125 - 32) + 32 end)
+          |> Enum.take(100)
+          |> List.to_string()
+
+        :large ->
+          Stream.repeatedly(fn -> :rand.uniform(125 - 32) + 32 end)
+          |> Enum.take(4000)
+          |> List.to_string()
+
+        other ->
+          other
+      end)
+
+    update_str = Enum.join(assignments, ", ")
+
+    Postgrex.query!(
+      conn,
+      """
+      UPDATE
+        items2
+      SET
+        #{update_str}
+      WHERE
+        id = $1
+      """,
+      [uuid | vals]
+    )
+  end
+end


### PR DESCRIPTION
Start the sync service with `iex -S mix`, evaluate `conn = Electric.DbPool`.

Run `M.prepare(conn)` once.

To insert a new row, run `M.insert(conn)`.

To update an existing row, run `M.update(conn, <id>, <updates>)` where `<updates>` is a keyword list, e.g. `val1: :small, val2: :large, index: 3`:

```
ex(16)> M.update conn, "557b45c0-7c4a-4fd0-b8a9-489fd00f6c8a", index: 2
%Postgrex.Result{
  command: :update,
  columns: nil,
  rows: nil,
  num_rows: 1,
  connection_id: 1819,
  messages: []
}
%Electric.Postgres.LogicalReplication.Messages.Begin{
  final_lsn: #Lsn<0/16A9E680>,
  commit_timestamp: ~U[2024-07-22 20:37:47.566570Z],
  xid: 1173
}
%Electric.Postgres.LogicalReplication.Messages.Update{
  relation_id: 17191,
  changed_key_tuple_data: nil,
  old_tuple_data: ["557b45c0-7c4a-4fd0-b8a9-489fd00f6c8a",
   "Iw&dmP8m864=d4C(;f:#}-<|E[y/d,G$.<RWQn?0;(\#{D>v!zg^m]\"U`WK*It*5FE7>Hm_pQ3}B_vgk<?Wv1i$%D##LPbN6:20U[!FXVGVDgD['tq#rP#RrP(+D30_U;3a$3J)$tAUHm-W}1X4<&\"{DgDA|VF*PxiUO:gH^gSp#2.B+,DwqamG'71mmfB]wNvrtYbEJQ+4J0):MBtq{Ajgr>\"PuWvjX[aAZ%yyIYxW4^|?ld({K42dm%S?8PI{c`^rgf(oIJo}Rz31edbfmC!kB*v(<zYS`MD\\D0#T3\\&s,Z'\"3qu1O4RaZaaT9Q&whQ:`ydwk#Z_(>:j7D]Fy!7gv7TPN*Vve2)1<Mu[i3q}gT$Vlh=1AVK=ZWA=_4\\=B('U@\",E:lzBhPi\\4OZIf;cjFm&_2}?N2/ZkD=&.<j}`[lKPaxq<?KZ\"Iw4/oW.bw8vk9!.\"&NWreke\">g_UrTK%P%9nj:m6X=-qXl+Y$Q70Re\"q\"iMG!l8>.vIt9@naGC5MoPkY-S`aFTZ&_-J7J;6rq%fA&(LYUXVTk4>gqu3r`Ksz0Rt^iy^%I)r-)1H/r&7VhsS#we.AQf[O2q\"L]9vCnq)ku_yJ%[Lv7}bMnqVQW-v7]d/ip'?/9{*K\\aod=IqiL-N}zDL^%9!p_?%g95ry#S3CguJ4L+]z6L@b0XA]['kVj$3?ug,zZ+p?*/[N0`bH#/X.[0j*!`c[tWV2Rrr:}C<:UY{0m]HpPkZ9(,Ghi,gC9:qpP/%4g4W#f-H%5_gz=T>wT|+31ncJ?O])Mc]v{\\rt}_ow_NX4_V@Fu^$Z.'R9I>D_'XYR\\Iz\\#|j)|_T$u@#o9q}Vy_6@taAx65Vj+)7Z[_^sEVTAK-Ij=<M]+%E'Jpb[sKH+)AZ'X'_xg2?it0AR;!v9`gqQLNX<`,9wW10nW\\WZaWQPczK@_FtDFJ0T=9X'E?`>,r&pha\#{QTOkgN/8`Mknr:\\49x*jn!Zr},?8tWavt{sR:E,J.`+&j*%mhq{Z:hDz2wX*\\Q*H%-6nu_2gb?5|-ZA=v\"i'4vS:Eto*KPFYxfJPIFgRmNlk!\"f_(JP{+9(UB'2DuwW$A*?Bu6j((\\}/?n8A4D9&m9n@`O8oG3Q*jQO`Nj_=c(0ZaZ(Z3Ro4<xG=1(2)GqS]X<w<>e)/Of;m3MbGG^+]6ovZ<X0$QS>rEqhp,!Oqq+dEfRwnp,r1fdC&+C0cmb#8>c)_3^Gpg2^:k0/-H{WIG7!^]U;]E&S`u08x8M8wc>fGWBy%Bnh/JNm\\<8kMG#jWd_R?DmVvm)#-$3ZQ5=sHIG8QuBCs=D6|T?nu5\"==:HU<y&RC!3p1fIbTR7;:<!*w6\"3*:1lH=%V8fCl$D8V>SWB3zSaUQrn|;'4=I)S{5f9Kj!?!mT'Mwxtbt0b3emnz0I&po,.H\\$k'v{G6<NgCMVlm7m$]pGzpa9{t6\"\"qWLZ%5^^F1XzVN;MY$e?Eyl4BeHD&2jj.ICZZ0XNn!R`I'$a=wT|$zQkSZnO0S\\d&B5#T8>OH\\|QCbgG]-7gmeXv_a>Zm;0feAg6LKrCB{bVd85L];'tv%J\"f}f\"Vk/S1</}i@R'P3Pp}4+HD|}peb-Zf%\\u!7&8Ce4_LRH^<z[w_9t!tGLk4kbEr+da\"LA8k-|q@#S!S[G$Y5ch?nz;YRX:tC6V|b_`_o=VqPcyy':uNSG+=`IpMme+'NWrPUF8-E/UoX3HI/7_wT_XB4ZhNvQ3HtL|Bj_V{*jSowg0>,Mlq<k|wZ[]O\"x(9d3_AHn$=Lbua1#/yxUoGER1\#{G:?,FXD#m7X*JwPX\\#8ch]13Oyal};:,4*i;e85;vY_8%W_/tA,&$\"b^Wb#m,AV>(X=9LdfICIQdzp;%66C-63rpthQ!v`FHV$x(U!V/v03ye0xQDY4\\|B_#a^cnG\\qE2*z6;tY&oXu<O!kg`d78TYT#^-7^!]96a\"|3J+F\":#E#(<Ybj|y;z5'.0=zcu2b-`f=H0JKaiuG{'s|7!j@V7)LH5?K.Wnc`%tfn/W0.GXhU'/\\34|jqj|<@^6tso.TyN}w`3'uAbr-t1L]puI^?|X$^A>ItJdpzZ|4;\\QzmTWB<d2S%i[!DBLQ&&AiXZksF&(pVkl8xhFydaTQSu/:DEfYonHs/(*#y)[I2Z12uQ*<w\\tHkpqso}Gq9/aYQ5RO<}Pyn2a5Kc]SlN[a4\"WQt+E3TpDP6!p>r4znX[ifTdH`SR}O3U`>@f1X`lhSqy>:()w/2k\\o92fv1y0{(17bht&[(UF4*35d_GKo{_wHC?fEvsJ,}%fMEm}T[p+@j|@X9F,R#nn(>5?*mxly_@$%/vclc>9Ea3wM5=L'@i%ZpPA\"UUab%R)8w1R%X=:zM]u>+0nH)!$6p)g_pjZMNz$@}lwGd]?Jtu@dwHyoeYT6/#U6J`R:;cU_p'QcV,\\tb8wg@'?2qyM.;Y;=P/^\"s3RSnX/f4|if?f8zHu:%}ZP-AOw{3u{#!SCi^Igg:|)'P%#SIDI#v}hV|^1^h1=f.sARrBMSGQWK/;#}R/k,tEh@xjKAFp/RWBEr^kXVW%y^9GYqgDgk4,!}O@u3'-j!a!ET|u4]cH\\:ZBQQg^i53%Kf)^@q@\\2w/5>ChR/c$@a+Fu|$GK/Yms<twe4Qq!0.b:1<V7Jh<C{HM^;]ZPQRtWSu#?+h=*11Ha1rPk-|dB%l*6Z8QC#Uv0F7mP_-AdAL.Nzx/BI['}x{o5tEOi*fUwm{'f(&kZ:.7M?`2h,Z!|KtvQ=U?a.$Og(5#'Z!IA[j3vf9GRKejpb--^a5Kr4EHx&[&9#D/u'F_Zj==0SKhQl4[RU]OP2!l_Y|8VPQXE$mGT2<=O#)c5iZ\\^/IxfB\\;a\\O!rBa@__8=^aim.1l_]@5SmlX8cftq|PkqM\\4-RhZ^p<\"RoDXZpMRL|Ja3WA[@5Pq0j<}{Ii(h\\0yl$eBtI*2*j6h7!{V|[*/1]`AQg/hRapW?LPN\\{6{\"qJ693&q*:YLt)//SE0d%,.Hw]4'ytEz<fdi0Xs",
   "H|X!TOfgud%7>a&ra_E})`o>}W=*}\\bt(@b<Y??$!Y,jw}OAf>{'r-&\\bO,7Q}B88lv{p\\K'u!|1HdS7^-#ZrBI*<8UO_G\\H9xaGEde2y\"m=\"q`J=EO%%-P^]s!+\\f72ywjVp[7LNEW{/rZv2s}Yz2C\\?`ISwoQv|\\>.lV-9Q{[B<g^(j>\"rsSjQlZ>g}WQ&w2YgB}uM[,I}q6ZD-CZ=i&9p!'((7q?)9)@k=yUwtY\"mbV5>.g*LR]5U)#Bt/>}.;W8x>acE!nRPOBaJl*_9h%.m#,?}+\"?SdK{/9t%-J>aj;z7.R?9t*3^!cQyBI:dQBHXGtGS:aa}9ux::6hg%h\"A$b{GTp61(]BQqQ*%@=NwykQqw69N11L|:;a}TN=y,Z4[;Wxu-O{&Ui%QfgF$oo$5,BLMJ:f39<Ly;{^Sm),A>vM$2Rd\"N=BZ;&}iQV*jST*A/;(ND?b[*7\\Bd>K:%\"^Rp';6w,Sg#NS[{jTuu.SwmE@n[A$PWB425AOlP>?$?wE5'\\l:r-sEK[j|7;]8GJxfALx*TJIHAb!f$iaA#PXEo_s!I7ayV>.x2ig.PN48x,#wDv(%&[1MA%b=k\"mq8qJ,^+iX,{aFP^(0gRQRAcKyD*qa}75sO6I1v`j){]sBVDixWw7h\\r3TPDx\\P@PwmKvc)}F%%z<lUVWQ0\\zYkC(^_w]N])Z&&7bjnIM6eX;mSQ}8c7)-{PDZ({,/B.*PSc}&799OX\"EG`R/d}vm|h*g7w2snIV/f[|W_}_cKL_xhm\\5m_nbj(!Ah6H#`Ffg_'oP!g'l_l`H'9`i:5S\"3Mz&9N[SFW(3h&i#>3ijfb^ltnb^2aBDSBi=U.Qd?h;JGIWTp6n4.R@$v\"n%/9XFH>)@#8j)fEw[W1Zt4cxqiSYOIU(|Grd}&GlbyCjOAU%9V37E+|U_=s92E=LKz=A8'<@v?R-%3Fe#71fB9Jkl\\%*{#5CfW[_oBb.oCAucp=(Rng0cdNzSobb\"W@Wp?0?h:t\\A=yM\"?1KU&toUB/h@27tV%mL}9{M6<HARhDM08_}8&'>0WUevU}<A'Sep}Zu`aP($)Xot,pnLS!mff}px&+;I{Jj3u;XaxF+WB)8),C-8{![Gag\"1KD}:$(s/O@pU=_J^D]nn0C1nJ4;emP*L$vJcnM/;5N+b0H;+LRMFlfV8AMNO<F?6:__0mm-b(_A&0h&%,e>=HV6'I*FvCHF\\q@;N\\%rekSQ\"@jHyP$1[ZCY6TV6q>cNcd{.444n3fv#oO_9CiX![$jOeT4B}d(p3|R%?=+uI7n&&!Q<5W`_?J2[A{qCghBaJ1fzxd6#3X1+\"v'OY0`'.-6sXap?6YBo,?yd1JZ8e>u`>,rnD36q'cnUeg'S=zO&q}jyUGd4`R?0wdd}#hHN!*gspNR/8ALrEWcdDNz4N.eYT@>`+dOWuOU^oFl3*g5_Bb/}7H}6)MY0vpzBxa::j_*=_EJ5-kiVZB,(R*TF(MQE`N\\R/'^J{8z_%hwQM=:M)mL'?XW!z1&+c^5/b\\8VjmY890#,#LD-O^7N\\X#%A,D\">#Y3Bz6kivTtIDGTo]v3Jo(t.h?_vqDW,qYNxR\"yIV($[@qwBtgWJhHhPiR(`\\kCSjPs[ZB<[Y3nU^uI7/8SKtwVm3]2JBk&2!p:d#[yKH_@V$iq4^I=e3|vP6a;4<}+(5hbfB{16Mh@\\[:P1_zH[K51Pl/D7`'(c^mOt#mF6&*(yGBP!,jx.oDu9mf9GLM#yr.Zz*{;R:X*eOc>[O(ThMq4f%a0Bn:X_Jv^+I@bbMJ.XIkr|}&V02BGP\\[#jr;u\")2KJPM$wv;xB{Jw7N^8n\"%/?m+8w?g9+[8Z^.=:|N?^,7tasy8`N(J`7|?,b|r4M+h|(b\"hUU0]H5&W%/.#,0PR^h@u:P]<V\">\"Z{_]O$Pn+If!DY7/b#bdpvW(66'JS.-mGO_\\():(N4@gxChVc,B,zT+Kj!iARk2*)f4,5FGXm)zhUh}jc1EdRZO;F*P94k\\62Emp@/dzn%LX&B,+W5eHo-z&#jEq9Txxg)Q?_iAT^,zkSAlttAn3JCUlnS-QJ[]@}UqK(Cyu9@^%`XVW@J;]xMwRp!6(qKctDM$`)PiXuRvR],ej^zb|A)aoTzQF(#H)v*&=&]&O,Q||*T]W[bxf-p.snsO\\hIkInG[RyIyk)T<Te}--|4(I95\"]ZD'-6(EGs,dga%.u%V,&m<kM3&5P$[i,$y|*aKj/3jVo_zt#VHkf\"Z:5IJx^;Lh$T6/cuBWBw3$nr!]I1),C</vz-FK<mW;Oy=NdM@O.O4skF$Msq)#v}sOO\\UJ:eAEQk^(3c&Y,?a{'nV[o_r!{OlxktoRd-/,9?BB3<4n3$T4h{SQQS+YUdv`sX5+P\"`7O'J)CLIS.xxS7:(ovVI)&Y+}FvDT:<VKC5XDx{J%wvXM`|3f{(mz{u#q*pxR=M|eKB|FhjMz?}|Aa(7T=1Bte7$z6W|sk>Bv#roZr,C4@53&uCL^2UJ2@7Xw5\"2{ZX[,Vq4-0H$[%R3WsHt$>3@%-sBRbv>}B,T1(yTenfMk\\(gL*r9[1V)kF|W5H{xOjDrdfH>/A%*Ys/cmGIUh:=(t{w1PJhxm.'>!<2z1)t1qm@i?AKBWBG5GEvkxI0[2<tcQ-zqu,!0yBo&$H]BtNLm{R-]9p)x#xka/C>'_Q2rAIKiqf0Zq&-XI9|-fJU7i@;nN}.\"GOMI}NR|!_gW?^V'r@Lb@ieR&F3EgZ,cb1=_gccr+e0740)=6Sa1owt?D7|n]sy?Pf{bj!!w\"PPIZO:0#\\$&jw]c'z$Zide;\"\"Mjgmg)G%hYA0L#l:y{'d(j0R-Ov(g^vAP6=pD]Z\\0YoZ_c&6J7[K#b!5|U<9\\,*&lOx0s^tl'9)C3|PqH<L7Pjmsd1mN;zI_$EjtBOs}%{TD7|gLkj{6rZU@vn)@Q#9SUsVJ0:NS-#2:ibM^.lH2$*Sa@jD.#_c1'YH\\6$:/y2u.h3_DkafG3w6.OoQYClj{ntR^Sf;hrtp1e\\W9|X-^HkTL]6G?0>[j`:i1#4ggT_M8((8oz#;T%Gr,C%b<(3s*J.Uy^^5&|$,4^N>z#+eMD+HAX$E71a8gCiP'bHt=??@pV`>E`\\ViQZl2(5}}%E^tNx4B[4A9gdOWB&IplexvXrhNM>PHy7F^*irnq=m4pK2qcl@Apr_R2j;Q|9<uHO_Qc1sL$K`[Wq/\"yW;r$z]fNv-1)Z#U1<$(T1<qG`Y8?c6_goegF?^C0/4C7}{\\z%W`[YCH_fO74yD=W32B$ZoUZ.v:hIUYA9EcW31@D&\\01Ic>Zi3.ogjJvA,bzQQId\"!=>g;cR0cI:HZwk<r{]m/w}esr0@F!vM![,5ECenc+|T3H8%O?;K)vl3aED%OxPS\\9E6oMbqY$Vo>WmPfonG7h46FsJ8Nd)N{#/%|;:cYlo)@xc/CyK_J%'G\"YGwV}x95:nne&{V\"plqI_&2<<|'pH%b*RQrG+E.2/9m!xaQOzTY*2fJ!9d3q-bS]4tD%(W|8+8mn|vc&'dHk{s^=mMgY>cLvR#0\"^:P(\\T<^MW0A^=8SCYVLwr'am?w8Q:8js#yp46C'_}/k'cWwbB8\\.*J{:yZ`.K2`>?hVl%0\"M!agncOOYpX^>D=aulw+^sAyT!wS=HU7>s[W}F}v+*0z_bWI&)zU]4n)t+$Ga\\w]J\"Z;`+^1wM=TdSM.g<y:;PtSysF$/=<St!iykl=-g'1Ds\"d{]yRP([2[Q!(6ce\\X-eBW2&^Ad7:fVdkv'<4fUfDy7l^JPo0)enqZiD=2vSK\"P[]r0(PCa6Nhk/!D8t{_UT7I{[RL$xnU'.3TdDx(-;kp+P}g.\"`wl!RoTby_zm#}yYG/KI2QT}r\\\\?R9Nnjk^9wl^ZHJ*9Wsc3A_w$/nd,pwVtoX{x-;\\$I&8EcSpL[*2:cJ>hHhAcm}!I,.'i#_AJ<nAi%\"kP?\"&P]$OP0^)>(n'/vCr5j,RfsMZ$#<5w>cPhacY1B<5#iJfb8BLQu*wDE<[s\"EdSaGgc%rJVGOtEbg",
   "1"],
  tuple_data: ["557b45c0-7c4a-4fd0-b8a9-489fd00f6c8a", :unchanged_toast,
   :unchanged_toast, "2"]
}
%Electric.Postgres.LogicalReplication.Messages.Commit{
  flags: [],
  lsn: #Lsn<0/16A9E680>,
  end_lsn: #Lsn<0/16A9E6B0>,
  commit_timestamp: ~U[2024-07-22 20:37:47.566570Z]
}

23:37:47.571 [info] Received transaction 1173 from Postgres at 0/16A9E680
```

As can be seen above, only `tuple_data` has `:unchanged_toast` values. That means, the current values for those columns remain the same as in `old_tuple_data`.