### PR TITLE
fix: Cast the initial values in the log to strings to be consistent with the ongoing values

### DIFF
--- a/.changeset/flappy-moose-balloon.md
+++ b/.changeset/flappy-moose-balloon.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/next": patch
+---
+
+The initial values in the log are now strings to be consistent with the ongoing values

--- a/packages/sync-service/lib/electric/shapes/querying.ex
+++ b/packages/sync-service/lib/electric/shapes/querying.ex
@@ -1,13 +1,14 @@
 defmodule Electric.Shapes.Querying do
   alias Electric.Utils
   alias Electric.Shapes.Shape
+  alias Electric.Postgres.Inspector
 
   @type row :: [term()]
 
   @spec stream_initial_data(DBConnection.t(), Shape.t()) ::
           {Postgrex.Query.t(), Enumerable.t(row())}
-  def stream_initial_data(conn, %Shape{} = shape) do
-    table = Utils.relation_to_sql(shape.root_table)
+  def stream_initial_data(conn, %Shape{root_table: root_table} = shape) do
+    table = Utils.relation_to_sql(root_table)
 
     where =
       if not is_nil(shape.where), do: " WHERE " <> shape.where.query, else: ""
@@ -16,7 +17,7 @@ defmodule Electric.Shapes.Querying do
       Postgrex.prepare!(
         conn,
         table,
-        ~s|SELECT * FROM #{table} #{where}|
+        ~s|SELECT #{columns(root_table, conn)} FROM #{table} #{where}|
       )
 
     stream =
@@ -24,5 +25,12 @@ defmodule Electric.Shapes.Querying do
       |> Stream.flat_map(& &1.rows)
 
     {query, stream}
+  end
+
+  defp columns(root_table, conn) do
+    root_table
+    |> Inspector.load_table_info(conn)
+    |> Enum.map(&"#{&1.name}::text")
+    |> Enum.join(", ")
   end
 end

--- a/packages/sync-service/lib/electric/shapes/querying.ex
+++ b/packages/sync-service/lib/electric/shapes/querying.ex
@@ -30,7 +30,7 @@ defmodule Electric.Shapes.Querying do
   defp columns(root_table, conn) do
     root_table
     |> Inspector.load_table_info(conn)
-    |> Enum.map(&~s("#{&1.name}"::text))
+    |> Enum.map(&~s("#{Utils.escape_quotes(&1.name)}"::text))
     |> Enum.join(", ")
   end
 end

--- a/packages/sync-service/lib/electric/shapes/querying.ex
+++ b/packages/sync-service/lib/electric/shapes/querying.ex
@@ -30,7 +30,7 @@ defmodule Electric.Shapes.Querying do
   defp columns(root_table, conn) do
     root_table
     |> Inspector.load_table_info(conn)
-    |> Enum.map(&"#{&1.name}::text")
+    |> Enum.map(&~s("#{&1.name}"::text))
     |> Enum.join(", ")
   end
 end

--- a/packages/sync-service/lib/electric/utils.ex
+++ b/packages/sync-service/lib/electric/utils.ex
@@ -197,7 +197,7 @@ defmodule Electric.Utils do
     ~s|"#{escape_quotes(schema)}"."#{escape_quotes(table)}"|
   end
 
-  defp escape_quotes(text), do: :binary.replace(text, ~S|"|, ~S|""|, [:global])
+  def escape_quotes(text), do: :binary.replace(text, ~S|"|, ~S|""|, [:global])
 
   @doc """
   Applies either an anonymous function or a MFA tuple, prepending the given arguments

--- a/packages/sync-service/test/electric/shapes/querying_test.exs
+++ b/packages/sync-service/test/electric/shapes/querying_test.exs
@@ -46,4 +46,29 @@ defmodule Electric.Shapes.QueryingTest do
     assert %{columns: ["id", "value"]} = query_info
     assert [[_, "4"], [_, "5"]] = Enum.to_list(stream)
   end
+
+  test "copes with column names with spaces in them", %{db_conn: conn} do
+    Postgrex.query!(
+      conn,
+      """
+      CREATE TABLE items (
+        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+        "col with spaces" INTEGER
+      )
+      """,
+      []
+    )
+
+    Postgrex.query!(
+      conn,
+      ~s|INSERT INTO items ("col with spaces") VALUES (1), (2), (3), (4), (5)|,
+      []
+    )
+
+    assert {query_info, stream} =
+             Querying.stream_initial_data(conn, %Shape{root_table: {"public", "items"}})
+
+    assert %{columns: ["id", "col with spaces"]} = query_info
+    assert [[_, "1"], [_, "2"], [_, "3"], [_, "4"], [_, "5"]] = Enum.to_list(stream)
+  end
 end

--- a/packages/sync-service/test/electric/shapes/querying_test.exs
+++ b/packages/sync-service/test/electric/shapes/querying_test.exs
@@ -47,13 +47,13 @@ defmodule Electric.Shapes.QueryingTest do
     assert [[_, "4"], [_, "5"]] = Enum.to_list(stream)
   end
 
-  test "copes with column names with spaces in them", %{db_conn: conn} do
+  test "allows column names to have special characters", %{db_conn: conn} do
     Postgrex.query!(
       conn,
       """
       CREATE TABLE items (
         id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-        "col with spaces" INTEGER
+        "col with "" in it" INTEGER
       )
       """,
       []
@@ -61,14 +61,14 @@ defmodule Electric.Shapes.QueryingTest do
 
     Postgrex.query!(
       conn,
-      ~s|INSERT INTO items ("col with spaces") VALUES (1), (2), (3), (4), (5)|,
+      ~s|INSERT INTO items ("col with "" in it") VALUES (1), (2), (3), (4), (5)|,
       []
     )
 
     assert {query_info, stream} =
              Querying.stream_initial_data(conn, %Shape{root_table: {"public", "items"}})
 
-    assert %{columns: ["id", "col with spaces"]} = query_info
+    assert %{columns: ["id", ~s(col with " in it)]} = query_info
     assert [[_, "1"], [_, "2"], [_, "3"], [_, "4"], [_, "5"]] = Enum.to_list(stream)
   end
 end

--- a/packages/sync-service/test/electric/shapes/querying_test.exs
+++ b/packages/sync-service/test/electric/shapes/querying_test.exs
@@ -23,7 +23,7 @@ defmodule Electric.Shapes.QueryingTest do
              Querying.stream_initial_data(conn, %Shape{root_table: {"public", "items"}})
 
     assert %{columns: ["id", "value"]} = query_info
-    assert [[_, 1], [_, 2], [_, 3], [_, 4], [_, 5]] = Enum.to_list(stream)
+    assert [[_, "1"], [_, "2"], [_, "3"], [_, "4"], [_, "5"]] = Enum.to_list(stream)
   end
 
   test "respects the where clauses", %{db_conn: conn} do
@@ -44,6 +44,6 @@ defmodule Electric.Shapes.QueryingTest do
     assert {query_info, stream} = Querying.stream_initial_data(conn, shape)
 
     assert %{columns: ["id", "value"]} = query_info
-    assert [[_, 4], [_, 5]] = Enum.to_list(stream)
+    assert [[_, "4"], [_, "5"]] = Enum.to_list(stream)
   end
 end

--- a/packages/sync-service/test/support/db_structure_setup.ex
+++ b/packages/sync-service/test/support/db_structure_setup.ex
@@ -1,11 +1,12 @@
 defmodule Support.DbStructureSetup do
-  def with_basic_tables(%{db_conn: conn}) do
+  def with_basic_tables(%{db_conn: conn} = context) do
     Postgrex.query!(
       conn,
       """
       CREATE TABLE items (
         id UUID PRIMARY KEY,
         value TEXT NOT NULL
+        #{additional_fields(context)}
       )
       """,
       []
@@ -29,4 +30,7 @@ defmodule Support.DbStructureSetup do
   end
 
   def with_sql_execute(_), do: :ok
+
+  defp additional_fields(%{additional_fields: additional_fields}), do: ", " <> additional_fields
+  defp additional_fields(_), do: nil
 end


### PR DESCRIPTION
Fixes #100 