### PR TITLE
feat: send only patch updates & split up PK changes or PK-less updates

### DIFF
--- a/.changeset/tasty-seahorses-sparkle.md
+++ b/.changeset/tasty-seahorses-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@electric-sql/next": minor
+---
+
+Update the client to work correctly with patch (instead of full) updates

--- a/.changeset/wicked-tools-rule.md
+++ b/.changeset/wicked-tools-rule.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": minor
+---
+
+Send only changed columns and PKs on updates instead of full rows, and only PKs on deletes. Also tackle a case where we change a PK of a row - this is split into a delete+insert operations that reference each other using header metadata

--- a/packages/sync-service/lib/electric/postgres/inspector/direct_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/direct_inspector.ex
@@ -16,8 +16,8 @@ defmodule Electric.Postgres.Inspector.DirectInspector do
     JOIN pg_namespace ON relnamespace = pg_namespace.oid
     JOIN pg_attribute ON attrelid = pg_class.oid AND attnum >= 0
     JOIN pg_type ON atttypid = pg_type.oid
-    JOIN pg_index ON indrelid = pg_class.oid AND indisprimary
-    WHERE relname = $1 AND nspname = $2
+    LEFT JOIN pg_index ON indrelid = pg_class.oid AND indisprimary
+    WHERE relname = $1 AND nspname = $2 AND relkind = 'r'
     ORDER BY pg_class.oid, attnum
     """
 

--- a/packages/sync-service/lib/electric/postgres/replication_client/collector.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/collector.ex
@@ -132,7 +132,7 @@ defmodule Electric.Postgres.ReplicationClient.Collector do
     {%Transaction{
        txn
        | changes: Enum.reverse(txn.changes),
-         last_log_offset: LogOffset.new(txn.lsn, max(0, state.tx_op_index - 1))
+         last_log_offset: LogOffset.new(txn.lsn, max(0, state.tx_op_index - 2))
      }, %__MODULE__{state | transaction: nil, tx_op_index: nil}}
   end
 

--- a/packages/sync-service/lib/electric/postgres/replication_client/collector.ex
+++ b/packages/sync-service/lib/electric/postgres/replication_client/collector.ex
@@ -149,6 +149,8 @@ defmodule Electric.Postgres.ReplicationClient.Collector do
 
   @spec prepend_change(Changes.change(), t()) :: t()
   defp prepend_change(change, %__MODULE__{transaction: txn, tx_op_index: tx_op_index} = state) do
-    %{state | transaction: Transaction.prepend_change(txn, change), tx_op_index: tx_op_index + 1}
+    # We're adding 2 to the op index because it's possible we're splitting some of the operations before storage.
+    # This gives us headroom for splitting any operation into 2.
+    %{state | transaction: Transaction.prepend_change(txn, change), tx_op_index: tx_op_index + 2}
   end
 end

--- a/packages/sync-service/lib/electric/replication/changes.ex
+++ b/packages/sync-service/lib/electric/replication/changes.ex
@@ -162,6 +162,10 @@ defmodule Electric.Replication.Changes do
           }
   end
 
+  def build_key(rel, record, []) do
+    IO.iodata_to_binary([prefix_from_rel(rel), ?/, Map.values(record)])
+  end
+
   def build_key(rel, record, pk_cols) when is_list(pk_cols) do
     IO.iodata_to_binary([prefix_from_rel(rel), ?/, record |> Map.take(pk_cols) |> Map.values()])
   end
@@ -184,37 +188,6 @@ defmodule Electric.Replication.Changes do
     do: %{change | key: build_key(relation, old_record, pk)}
 
   defp prefix_from_rel({schema, table}), do: [?", schema, ?", ?., ?", table, ?"]
-
-  def to_json_value(%NewRecord{record: record}), do: record
-  def to_json_value(%UpdatedRecord{record: record}), do: record
-  def to_json_value(%DeletedRecord{}), do: nil
-
-  def get_action(%NewRecord{}), do: "insert"
-  def get_action(%UpdatedRecord{}), do: "update"
-  def get_action(%DeletedRecord{}), do: "delete"
-
-  @doc """
-  ## Examples
-
-      iex> get_log_offset(%NewRecord{log_offset: {1, 2}})
-      {1, 2}
-
-      iex> get_log_offset(%UpdatedRecord{log_offset: {1, 2}})
-      {1, 2}
-
-      iex> get_log_offset(%DeletedRecord{log_offset: {1, 2}})
-      {1, 2}
-
-      iex> get_log_offset(%TruncatedRelation{log_offset: {1, 2}})
-      {1, 2}
-
-      iex> get_log_offset(%NewRecord{})
-      ** (FunctionClauseError) no function clause matching in Electric.Replication.Changes.get_log_offset/1
-  """
-  def get_log_offset(%NewRecord{log_offset: offset}) when offset != nil, do: offset
-  def get_log_offset(%UpdatedRecord{log_offset: offset}) when offset != nil, do: offset
-  def get_log_offset(%DeletedRecord{log_offset: offset}) when offset != nil, do: offset
-  def get_log_offset(%TruncatedRelation{log_offset: offset}) when offset != nil, do: offset
 
   @doc """
   Convert an UpdatedRecord into the corresponding NewRecord or DeletedRecord

--- a/packages/sync-service/lib/electric/shape_cache.ex
+++ b/packages/sync-service/lib/electric/shape_cache.ex
@@ -2,9 +2,9 @@ defmodule Electric.ShapeCacheBehaviour do
   @moduledoc """
   Behaviour defining the ShapeCache functions to be used in mocks
   """
+  alias Electric.ShapeCache.Storage
   alias Electric.Shapes.Shape
   alias Electric.Replication.LogOffset
-  alias Electric.Replication.Changes
 
   @type shape_id :: String.t()
   @type shape_def :: Shape.t()
@@ -13,8 +13,7 @@ defmodule Electric.ShapeCacheBehaviour do
   @callback append_to_log!(
               shape_id(),
               LogOffset.t(),
-              non_neg_integer(),
-              [Changes.change()],
+              [Storage.prepared_change()],
               keyword()
             ) :: :ok
 
@@ -34,7 +33,6 @@ defmodule Electric.ShapeCache do
   alias Electric.Shapes.Querying
   alias Electric.Shapes.Shape
   alias Electric.Replication.LogOffset
-  alias Electric.Replication.Changes
   use GenServer
   @behaviour Electric.ShapeCacheBehaviour
 
@@ -87,12 +85,11 @@ defmodule Electric.ShapeCache do
   @spec append_to_log!(
           shape_id(),
           LogOffset.t(),
-          non_neg_integer(),
-          [Changes.change()],
+          [Storage.prepared_change()],
           keyword()
         ) :: :ok
-  def append_to_log!(shape_id, latest_offset, xid, relevant_changes, opts) do
-    :ok = Storage.append_to_log!(shape_id, xid, relevant_changes, opts[:storage])
+  def append_to_log!(shape_id, latest_offset, relevant_changes, opts) do
+    :ok = Storage.append_to_log!(shape_id, relevant_changes, opts[:storage])
 
     update_shape_latest_offset(shape_id, latest_offset, opts)
   end

--- a/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/in_memory_storage.ex
@@ -102,16 +102,13 @@ defmodule Electric.ShapeCache.InMemoryStorage do
     :ok
   end
 
-  def append_to_log!(shape_id, xid, changes, opts) do
+  def append_to_log!(shape_id, changes, opts) do
     ets_table = opts.log_ets_table
 
     changes
-    |> Enum.map(fn
-      %{relation: _, key: key} = change ->
-        value = Changes.to_json_value(change)
-        action = Changes.get_action(change)
-        offset = storage_offset(Changes.get_log_offset(change))
-        {{shape_id, offset}, xid, key, action, value}
+    |> Enum.map(fn {offset, key, action, value, header_data} ->
+      offset = storage_offset(offset)
+      {{shape_id, offset}, key, action, value, header_data}
     end)
     |> then(&:ets.insert(ets_table, &1))
 
@@ -144,15 +141,15 @@ defmodule Electric.ShapeCache.InMemoryStorage do
   end
 
   defp snapshot_storage_item_to_log_item({_shape_id, snapshot_log_offset}, {key, value}) do
-    %{key: key, value: value, headers: %{action: "insert"}, offset: snapshot_log_offset}
+    %{key: key, value: value, headers: %{action: :insert}, offset: snapshot_log_offset}
   end
 
   # Turns a stored log item into a log item
   # by modifying the turning the tuple offset
   # back into a LogOffset value.
-  defp log_storage_item_to_log_item({_shape_id, position}, {_, xid, key, action, value}) do
+  defp log_storage_item_to_log_item({_shape_id, position}, {_, key, action, value, header_data}) do
     offset = LogOffset.new(position)
-    %{key: key, value: value, headers: %{action: action, txid: xid}, offset: offset}
+    %{key: key, value: value, headers: Map.put(header_data, :action, action), offset: offset}
   end
 
   # Turns a LogOffset into a tuple representation

--- a/packages/sync-service/test/electric/plug/router_test.exs
+++ b/packages/sync-service/test/electric/plug/router_test.exs
@@ -239,10 +239,9 @@ defmodule Electric.Plug.RouterTest do
 
       assert %{status: 200} = conn = Task.await(task)
 
-      assert [%{"key" => ^key, "value" => value}, _] = Jason.decode!(conn.resp_body)
-
-      # No extra keys should be present, so this is equality assertion, not a match
-      assert value == %{"id" => "1", "value2" => "test value 2"}
+      # No extra keys should be present, so this is a pin
+      value = %{"id" => "1", "value2" => "test value 2"}
+      assert [%{"key" => ^key, "value" => ^value}, _] = Jason.decode!(conn.resp_body)
     end
 
     @tag with_sql: [

--- a/packages/sync-service/test/electric/postgres/replication_client/collector_test.exs
+++ b/packages/sync-service/test/electric/postgres/replication_client/collector_test.exs
@@ -265,8 +265,8 @@ defmodule Electric.Postgres.ReplicationClient.CollectorTest do
     {completed_txn, _updated_collector} = Collector.handle_message(commit_msg, collector)
 
     log_offset_1 = LogOffset.new(@test_lsn, 0)
-    log_offset_2 = LogOffset.increment(log_offset_1)
-    log_offset_3 = LogOffset.increment(log_offset_2)
+    log_offset_2 = LogOffset.new(@test_lsn, 2)
+    log_offset_3 = LogOffset.new(@test_lsn, 4)
 
     assert [
              %NewRecord{

--- a/packages/sync-service/test/electric/replication/changes_test.exs
+++ b/packages/sync-service/test/electric/replication/changes_test.exs
@@ -4,7 +4,6 @@ defmodule Electric.Replication.ChangesTest do
   alias Electric.Replication.Changes.NewRecord
   alias Electric.Replication.Changes.UpdatedRecord
   alias Electric.Replication.Changes.DeletedRecord
-  alias Electric.Replication.Changes.TruncatedRelation
 
   doctest Electric.Replication.Changes, import: true
 

--- a/packages/sync-service/test/electric/shape_cache/storage_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_test.exs
@@ -3,6 +3,7 @@ defmodule Electric.ShapeCache.StorageTest do
   alias Electric.ShapeCache.Storage
   alias Electric.ShapeCache.MockStorage
   alias Electric.Replication.LogOffset
+  alias Electric.Replication.Changes
 
   import Mox
 
@@ -16,7 +17,7 @@ defmodule Electric.ShapeCache.StorageTest do
     |> Mox.expect(:make_new_snapshot!, fn _, _, _, _, :opts -> :ok end)
     |> Mox.expect(:snapshot_exists?, fn _, :opts -> true end)
     |> Mox.expect(:get_snapshot, fn _, :opts -> {1, []} end)
-    |> Mox.expect(:append_to_log!, fn _, _, _, :opts -> :ok end)
+    |> Mox.expect(:append_to_log!, fn _, _, :opts -> :ok end)
     |> Mox.expect(:get_log_stream, fn _, _, _, :opts -> [] end)
     |> Mox.expect(:has_log_entry?, fn _, _, :opts -> [] end)
     |> Mox.expect(:cleanup!, fn _, :opts -> :ok end)
@@ -24,7 +25,7 @@ defmodule Electric.ShapeCache.StorageTest do
     Storage.make_new_snapshot!(shape_id, %{}, %{}, [], storage)
     Storage.snapshot_exists?(shape_id, storage)
     Storage.get_snapshot(shape_id, storage)
-    Storage.append_to_log!(shape_id, 1, [], storage)
+    Storage.append_to_log!(shape_id, [], storage)
     Storage.get_log_stream(shape_id, LogOffset.first(), storage)
     Storage.has_log_entry?(shape_id, 1, storage)
     Storage.cleanup!(shape_id, storage)
@@ -43,6 +44,119 @@ defmodule Electric.ShapeCache.StorageTest do
 
     assert_raise FunctionClauseError, fn ->
       Storage.get_log_stream("test", l2, l1, storage)
+    end
+  end
+
+  describe "prepare_change_for_storage/3" do
+    test "stores an entire `NewRecord` value" do
+      record = %Changes.NewRecord{
+        key: "my_key",
+        record: %{"pk" => "10", "hello" => "world"},
+        log_offset: LogOffset.first(),
+        relation: {"public", "test"}
+      }
+
+      assert Storage.prepare_change_for_storage(record, 1, ["pk"]) ==
+               [
+                 {LogOffset.first(), "my_key", :insert, %{"pk" => "10", "hello" => "world"},
+                  %{txid: 1, relation: ["public", "test"]}}
+               ]
+
+      # And with empty PK
+      assert Storage.prepare_change_for_storage(record, 1, []) ==
+               [
+                 {LogOffset.first(), "my_key", :insert, %{"pk" => "10", "hello" => "world"},
+                  %{txid: 1, relation: ["public", "test"]}}
+               ]
+    end
+
+    test "stores only PK of a `DeletedRecord` value" do
+      record = %Changes.DeletedRecord{
+        key: "my_key",
+        old_record: %{"pk" => "10", "hello" => "world"},
+        log_offset: LogOffset.first(),
+        relation: {"public", "test"}
+      }
+
+      assert Storage.prepare_change_for_storage(record, 1, ["pk"]) ==
+               [
+                 {LogOffset.first(), "my_key", :delete, %{"pk" => "10"},
+                  %{txid: 1, relation: ["public", "test"]}}
+               ]
+    end
+
+    test "stores entire `DeletedRecord` value if table has no PK" do
+      record = %Changes.DeletedRecord{
+        key: "my_key",
+        old_record: %{"value" => "10", "hello" => "world"},
+        log_offset: LogOffset.first(),
+        relation: {"public", "test"}
+      }
+
+      assert Storage.prepare_change_for_storage(record, 1, []) ==
+               [
+                 {LogOffset.first(), "my_key", :delete, %{"value" => "10", "hello" => "world"},
+                  %{txid: 1, relation: ["public", "test"]}}
+               ]
+    end
+
+    test "stores any changed columns and PK of an `UpdatedRecord` value" do
+      record =
+        Changes.UpdatedRecord.new(%{
+          key: "my_key",
+          old_record: %{"pk" => "10", "hello" => "world", "test" => "me"},
+          record: %{"pk" => "10", "hello" => "world", "test" => "new"},
+          log_offset: LogOffset.first(),
+          relation: {"public", "test"}
+        })
+
+      assert Storage.prepare_change_for_storage(record, 1, ["pk"]) ==
+               [
+                 {LogOffset.first(), "my_key", :update, %{"pk" => "10", "test" => "new"},
+                  %{txid: 1, relation: ["public", "test"]}}
+               ]
+    end
+
+    test "splits up the `UpdatedRecord` if a key was changed, adding a reference to both" do
+      record =
+        Changes.UpdatedRecord.new(%{
+          old_key: "old_key",
+          key: "new_key",
+          old_record: %{"pk" => "9", "hello" => "world", "test" => "me"},
+          record: %{"pk" => "10", "hello" => "world", "test" => "new"},
+          log_offset: LogOffset.first(),
+          relation: {"public", "test"}
+        })
+
+      assert Storage.prepare_change_for_storage(record, 1, ["pk"]) ==
+               [
+                 {LogOffset.first(), "old_key", :delete, %{"pk" => "9"},
+                  %{txid: 1, relation: ["public", "test"], key_change_to: "new_key"}},
+                 {LogOffset.increment(LogOffset.first()), "new_key", :insert,
+                  %{"pk" => "10", "hello" => "world", "test" => "new"},
+                  %{txid: 1, relation: ["public", "test"], key_change_from: "old_key"}}
+               ]
+    end
+
+    test "splits up the `UpdatedRecord` if a key was changed, adding a reference to both when no PK is defined" do
+      record =
+        Changes.UpdatedRecord.new(%{
+          old_key: "old_key",
+          key: "new_key",
+          old_record: %{"hello" => "world", "test" => "me"},
+          record: %{"hello" => "world", "test" => "new"},
+          log_offset: LogOffset.first(),
+          relation: {"public", "test"}
+        })
+
+      assert Storage.prepare_change_for_storage(record, 1, []) ==
+               [
+                 {LogOffset.first(), "old_key", :delete, %{"hello" => "world", "test" => "me"},
+                  %{txid: 1, relation: ["public", "test"], key_change_to: "new_key"}},
+                 {LogOffset.increment(LogOffset.first()), "new_key", :insert,
+                  %{"hello" => "world", "test" => "new"},
+                  %{txid: 1, relation: ["public", "test"], key_change_from: "old_key"}}
+               ]
     end
   end
 end

--- a/packages/sync-service/test/support/stub_inspector.ex
+++ b/packages/sync-service/test/support/stub_inspector.ex
@@ -1,7 +1,7 @@
 defmodule Support.StubInspector do
   @behaviour Electric.Postgres.Inspector
 
-  def stub_inspector(opts), do: {__MODULE__, opts}
+  def new(opts), do: {__MODULE__, opts}
 
   @impl true
   def load_column_info(_relation, column_list) when is_list(column_list) do

--- a/packages/sync-service/test/support/test_utils.ex
+++ b/packages/sync-service/test/support/test_utils.ex
@@ -1,0 +1,14 @@
+defmodule Support.TestUtils do
+  alias Electric.ShapeCache.Storage
+  alias Electric.Replication.Changes
+
+  @doc """
+  Preprocess a list of `Changes.data_change()` structs in the same way they
+  are preprocessed before reaching storage.
+  """
+  def preprocess_changes(changes, pk \\ ["id"], xid \\ 1) do
+    changes
+    |> Enum.map(&Changes.fill_key(&1, pk))
+    |> Enum.flat_map(&Storage.prepare_change_for_storage(&1, xid, pk))
+  end
+end

--- a/packages/typescript-client/src/client.ts
+++ b/packages/typescript-client/src/client.ts
@@ -492,18 +492,22 @@ export class Shape {
 
     messages.forEach((message) => {
       if (`key` in message) {
-        switch (message.headers?.[`action`]) {
+        dataMayHaveChanged = [`insert`, `update`, `delete`].includes(
+          message.headers.action
+        )
+
+        switch (message.headers.action) {
           case `insert`:
-          case `update`:
             this.data.set(message.key, message.value)
-            dataMayHaveChanged = true
-
             break
-
+          case `update`:
+            this.data.set(message.key, {
+              ...this.data.get(message.key)!,
+              ...message.value,
+            })
+            break
           case `delete`:
             this.data.delete(message.key)
-            dataMayHaveChanged = true
-
             break
         }
       }

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -41,6 +41,7 @@ describe(`Shape`, () => {
     expectedValue.set(`${issuesTableKey}/${id}`, {
       id: id,
       title: `test title`,
+      priority: `10`,
     })
 
     expect(map).toEqual(expectedValue)
@@ -50,6 +51,7 @@ describe(`Shape`, () => {
     issuesTableUrl,
     insertIssues,
     deleteIssue,
+    updateIssue,
     issuesTableKey,
     aborter,
   }) => {
@@ -67,6 +69,7 @@ describe(`Shape`, () => {
     expectedValue.set(`${issuesTableKey}/${id}`, {
       id: id,
       title: `test title`,
+      priority: `10`,
     })
     expect(map).toEqual(expectedValue)
 
@@ -77,12 +80,15 @@ describe(`Shape`, () => {
     const [id2] = await insertIssues({ title: `other title` })
     const [id3] = await insertIssues({ title: `other title2` })
     await deleteIssue({ id: id3, title: `other title2` })
+    // Test an update too because we're sending patches that should be correctly merged in
+    await updateIssue({ id: id2, title: `new title` })
     await sleep(100) // some time for electric to catch up
     await hasNotified
 
     expectedValue.set(`${issuesTableKey}/${id2}`, {
       id: id2,
-      title: `other title`,
+      title: `new title`,
+      priority: `10`,
     })
     expect(shape.valueSync).toEqual(expectedValue)
 
@@ -105,12 +111,14 @@ describe(`Shape`, () => {
     expectedValue1.set(`${issuesTableKey}/${id1}`, {
       id: id1,
       title: `foo1`,
+      priority: `10`,
     })
 
     const expectedValue2 = new Map()
     expectedValue2.set(`${issuesTableKey}/${id2}`, {
       id: id2,
       title: `foo2`,
+      priority: `10`,
     })
 
     let requestsMade = 0
@@ -180,10 +188,12 @@ describe(`Shape`, () => {
     expectedValue.set(`${issuesTableKey}/${id}`, {
       id: id,
       title: `test title`,
+      priority: `10`,
     })
     expectedValue.set(`${issuesTableKey}/${id2}`, {
       id: id2,
       title: `other title`,
+      priority: `10`,
     })
     expect(value).toEqual(expectedValue)
 


### PR DESCRIPTION
Closes #165, #181, #170.

This includes changes to the `Shape` class in JS to apply patches correctly.