### PR TITLE
fix: make sure generated keys are collision-resistant on tables with composite PKs

### DIFF
--- a/.changeset/spotty-radios-sing.md
+++ b/.changeset/spotty-radios-sing.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+fix: restructure generated keys to avoid possible colisions on multi-pk tables

--- a/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
+++ b/packages/sync-service/test/electric/shape_cache/storage_implementations_test.exs
@@ -88,13 +88,13 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
                   %{
                     offset: @snapshot_offset,
                     value: %{"id" => "00000000-0000-0000-0000-000000000001", "title" => "row1"},
-                    key: "\"public\".\"the-table\"/00000000-0000-0000-0000-000000000001",
+                    key: ~S|"public"."the-table"/"00000000-0000-0000-0000-000000000001"|,
                     headers: %{action: :insert}
                   },
                   %{
                     offset: @snapshot_offset,
                     value: %{"id" => "00000000-0000-0000-0000-000000000002", "title" => "row2"},
-                    key: "\"public\".\"the-table\"/00000000-0000-0000-0000-000000000002",
+                    key: ~S|"public"."the-table"/"00000000-0000-0000-0000-000000000002"|,
                     headers: %{action: :insert}
                   }
                 ]} = storage.get_snapshot(@shape_id, opts)
@@ -121,13 +121,13 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
                   %{
                     offset: @snapshot_offset,
                     value: %{"id" => "00000000-0000-0000-0000-000000000001", "title" => "row1"},
-                    key: "\"public\".\"the-table\"/00000000-0000-0000-0000-000000000001",
+                    key: ~S|"public"."the-table"/"00000000-0000-0000-0000-000000000001"|,
                     headers: %{action: :insert}
                   },
                   %{
                     offset: @snapshot_offset,
                     value: %{"id" => "00000000-0000-0000-0000-000000000002", "title" => "row2"},
-                    key: "\"public\".\"the-table\"/00000000-0000-0000-0000-000000000002",
+                    key: ~S|"public"."the-table"/"00000000-0000-0000-0000-000000000002"|,
                     headers: %{action: :insert}
                   }
                 ]} = storage.get_snapshot(@shape_id, opts)
@@ -182,7 +182,7 @@ defmodule Electric.ShapeCache.StorageImplimentationsTest do
         stream = storage.get_log_stream(@shape_id, LogOffset.first(), LogOffset.last(), opts)
         [entry] = Enum.to_list(stream)
 
-        assert entry.key == ~S|"public"."test_table"/123|
+        assert entry.key == ~S|"public"."test_table"/"123"|
         assert entry.value == %{"id" => "123", "name" => "Test"}
         assert entry.headers == %{action: :insert, txid: 1, relation: ["public", "test_table"]}
         assert entry.offset == offset

--- a/packages/typescript-client/test/client.test.ts
+++ b/packages/typescript-client/test/client.test.ts
@@ -38,7 +38,7 @@ describe(`Shape`, () => {
     })
 
     const expectedValue = new Map()
-    expectedValue.set(`${issuesTableKey}/${id}`, {
+    expectedValue.set(`${issuesTableKey}/"${id}"`, {
       id: id,
       title: `test title`,
       priority: `10`,
@@ -66,7 +66,7 @@ describe(`Shape`, () => {
     const map = await shape.value
 
     const expectedValue = new Map()
-    expectedValue.set(`${issuesTableKey}/${id}`, {
+    expectedValue.set(`${issuesTableKey}/"${id}"`, {
       id: id,
       title: `test title`,
       priority: `10`,
@@ -85,7 +85,7 @@ describe(`Shape`, () => {
     await sleep(100) // some time for electric to catch up
     await hasNotified
 
-    expectedValue.set(`${issuesTableKey}/${id2}`, {
+    expectedValue.set(`${issuesTableKey}/"${id2}"`, {
       id: id2,
       title: `new title`,
       priority: `10`,
@@ -108,14 +108,14 @@ describe(`Shape`, () => {
     await insertIssues({ id: id1, title: `foo1` })
 
     const expectedValue1 = new Map()
-    expectedValue1.set(`${issuesTableKey}/${id1}`, {
+    expectedValue1.set(`${issuesTableKey}/"${id1}"`, {
       id: id1,
       title: `foo1`,
       priority: `10`,
     })
 
     const expectedValue2 = new Map()
-    expectedValue2.set(`${issuesTableKey}/${id2}`, {
+    expectedValue2.set(`${issuesTableKey}/"${id2}"`, {
       id: id2,
       title: `foo2`,
       priority: `10`,
@@ -185,12 +185,12 @@ describe(`Shape`, () => {
 
     const value = await hasNotified
     const expectedValue = new Map()
-    expectedValue.set(`${issuesTableKey}/${id}`, {
+    expectedValue.set(`${issuesTableKey}/"${id}"`, {
       id: id,
       title: `test title`,
       priority: `10`,
     })
-    expectedValue.set(`${issuesTableKey}/${id2}`, {
+    expectedValue.set(`${issuesTableKey}/"${id2}"`, {
       id: id2,
       title: `other title`,
       priority: `10`,

--- a/packages/typescript-client/test/integration.test.ts
+++ b/packages/typescript-client/test/integration.test.ts
@@ -199,9 +199,9 @@ describe(`HTTP Sync`, () => {
     // This test doesn't merge in updates, so we don't have `priority` on the row.
     expect(shapeData).toEqual(
       new Map([
-        [`${issuesTableKey}/${rowId}`, { id: rowId, title: `foo1` }],
+        [`${issuesTableKey}/"${rowId}"`, { id: rowId, title: `foo1` }],
         [
-          `${issuesTableKey}/${secondRowId}`,
+          `${issuesTableKey}/"${secondRowId}"`,
           { id: secondRowId, title: `foo2`, priority: `10` },
         ],
       ])
@@ -447,7 +447,7 @@ describe(`HTTP Sync`, () => {
     await clearShape(issuesTableUrl, issueStream.shapeId!)
 
     expect(shapeData).toEqual(
-      new Map([[`${issuesTableKey}/${id1}`, { id: id1, title: `foo1` }]])
+      new Map([[`${issuesTableKey}/"${id1}"`, { id: id1, title: `foo1` }]])
     )
   })
 


### PR DESCRIPTION
Closes #184 