### PR TITLE
fix: use 'pnpm publish -r' so workspace dependencies are resolved correctly

### DIFF
--- a/.github/workflows/changesets_release.yml
+++ b/.github/workflows/changesets_release.yml
@@ -28,8 +28,8 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm exec changeset version
-          publish: pnpm exec changeset publish
+          version: pnpm ci:version
+          publish: pnpm ci:publish
           title: 'chore: publish new package versions'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "example-backend:up": "dotenv -e .env.dev -- docker compose -f ./.support/docker-compose.yml up -d ",
     "example-backend:down": "dotenv  -e .env.dev -- docker compose -f .support/docker-compose.yml down --volumes",
-    "stylecheck-all": "pnpm --if-present --recursive run stylecheck"
+    "stylecheck-all": "pnpm --if-present --recursive run stylecheck",
+    "ci:version": "pnpm exec changset version",
+    "ci:publish": "pnpm publish -r"
   }
 }

--- a/packages/react-hooks/src/react-hooks.tsx
+++ b/packages/react-hooks/src/react-hooks.tsx
@@ -5,7 +5,7 @@ import {
   ShapeStreamOptions,
 } from '@electric-sql/next'
 import React, { createContext, useCallback, useContext, useRef } from 'react'
-import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector'
+import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector.js'
 
 interface ShapeContextType {
   getShape: (shapeStream: ShapeStream) => Shape


### PR DESCRIPTION
ref: https://pnpm.io/using-changesets

This is the error we we're getting before: https://github.com/electric-sql/electric-next/actions/runs/10098119262

I think @electric-sql/react should republish when this merges without needing a new changeset since it failed last time.