### PR TITLE
Fix: typescript resolution when building types

### DIFF
--- a/packages/react-hooks/tsconfig.build.json
+++ b/packages/react-hooks/tsconfig.build.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
@@ -28,7 +29,7 @@
     /* Modules */
     "module": "ESNext" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "Bundler",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */

--- a/packages/typescript-client/tsconfig.build.json
+++ b/packages/typescript-client/tsconfig.build.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
@@ -28,7 +29,7 @@
     /* Modules */
     "module": "ESNext" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "Bundler",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "incremental": false,
+    "noEmit": false
+  },
+  "include": ["**/*", ".*.js"]
+}


### PR DESCRIPTION
Add a base tsconfig build config which includes everything in the monorepo so packages can resolve each other.

Fix for https://github.com/electric-sql/electric-next/actions/runs/10101397601/job/27934902207#step:6:6