### PR TITLE
feat(sync-service): Support connecting to the database over IPv6

### DIFF
--- a/.changeset/selfish-terms-look.md
+++ b/.changeset/selfish-terms-look.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Support connecting to the database over IPv6 by configuring the sync service with DATABASE_USE_IPV6=true.

--- a/packages/sync-service/config/runtime.exs
+++ b/packages/sync-service/config/runtime.exs
@@ -22,9 +22,14 @@ if Config.config_env() == :test do
       database: "postgres"
     ]
 else
-  {:ok, connection_opts} =
+  {:ok, database_url_config} =
     env!("DATABASE_URL", :string)
     |> Electric.Config.parse_postgresql_uri()
+
+  database_ipv6_config =
+    env!("DATABASE_USE_IPV6", :boolean, false)
+
+  connection_opts = [ipv6: database_ipv6_config] ++ database_url_config
 
   config :electric, connection_opts: connection_opts
 end

--- a/packages/sync-service/lib/electric/connection_manager.ex
+++ b/packages/sync-service/lib/electric/connection_manager.ex
@@ -69,6 +69,7 @@ defmodule Electric.ConnectionManager do
       opts
       |> Keyword.fetch!(:connection_opts)
       |> update_ssl_opts()
+      |> update_tcp_opts()
 
     replication_opts =
       opts
@@ -306,5 +307,16 @@ defmodule Electric.ConnectionManager do
   # `sslmode=verify-ca` and `sslmode=verify-full` in the database URL parsing code.
   defp ssl_verify_opts do
     [verify: :verify_none]
+  end
+
+  defp update_tcp_opts(connection_opts) do
+    tcp_opts =
+      if connection_opts[:ipv6] do
+        [:inet6]
+      else
+        []
+      end
+
+    Keyword.put(connection_opts, :socket_options, tcp_opts)
   end
 end


### PR DESCRIPTION
Closes https://github.com/electric-sql/electric-next/issues/191.

This must be explicitly enabled by passing `DATABASE_USE_IPV6=true` to the sync service at startup. When running in Docker, the container must use an IPv6-compatible Docker network. Here's an example of setting such a network up for Docker Compose:
```yaml
# docker-compose.yaml

name: "electric_quickstart"

networks:
  # An IPv6-enabled network is necessary for the sync service to connect to
  # databases that are only reachable at IPv6 addresses. IPv4 can also be used as usual with
  # this network.
  ip6net:
    enable_ipv6: true

services:
  electric:
    image: electricsql/electric-next
    environment:
      DATABASE_URL: postgresql://...supabase.co:5432/postgres
      DATABASE_USE_IPV6: true
    ports:
      - "3000:3000"
    networks:
      - ip6net
```

When using `docker run`, it is easier to just use the host network mode:
```
docker run --rm --net=host \
    -e DATABASE_URL=postgresql://...supabase.co:5432/postgres \
    -e DATABASE_USE_IPV6=true \
    electricsql/electric-next
```