### PR TITLE
fix: Fix 500 for two concurrent requests of the same shape that is not in cache

### DIFF
--- a/.changeset/calm-hats-shake.md
+++ b/.changeset/calm-hats-shake.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Fix issue that would return a 500 for one of the requests when there are two concurrent requests for the same shape that is not already in cache

--- a/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
+++ b/packages/sync-service/lib/electric/postgres/inspector/ets_inspector.ex
@@ -16,12 +16,10 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
       )
 
   @impl Electric.Postgres.Inspector
-  def load_column_info({namespace, tbl}, opts) do
-    ets_table = Access.get(opts, :pg_info_table, @default_pg_info_table)
-
-    case :ets.lookup_element(ets_table, {{namespace, tbl}, :columns}, 2, :not_found) do
+  def load_column_info({_namespace, _table_name} = table, opts) do
+    case column_info_from_ets(table, opts) do
       :not_found ->
-        case GenServer.call(opts[:server], {:load_column_info, {namespace, tbl}}) do
+        case GenServer.call(opts[:server], {:load_column_info, table}) do
           {:error, err, stacktrace} -> reraise err, stacktrace
           result -> result
         end
@@ -46,23 +44,30 @@ defmodule Electric.Postgres.Inspector.EtsInspector do
   end
 
   @impl GenServer
-  def handle_call({:load_column_info, {namespace, tbl}}, _from, state) do
-    case :ets.lookup(state.pg_info_table, {{namespace, tbl}, :columns}) do
-      [found] ->
-        {:reply, {:ok, found}, state}
-
-      [] ->
-        case DirectInspector.load_column_info({namespace, tbl}, state.pg_pool) do
+  def handle_call({:load_column_info, table}, _from, state) do
+    case column_info_from_ets(table, state) do
+      :not_found ->
+        case DirectInspector.load_column_info(table, state.pg_pool) do
           :table_not_found ->
             {:reply, :table_not_found, state}
 
           {:ok, info} ->
             # store
-            :ets.insert(state.pg_info_table, {{{namespace, tbl}, :columns}, info})
+            :ets.insert(state.pg_info_table, {{table, :columns}, info})
             {:reply, {:ok, info}, state}
         end
+
+      found ->
+        {:reply, {:ok, found}, state}
     end
   rescue
     e -> {:reply, {:error, e, __STACKTRACE__}, state}
+  end
+
+  @column_info_position 2
+  defp column_info_from_ets(table, opts_or_state) do
+    ets_table = Access.get(opts_or_state, :pg_info_table, @default_pg_info_table)
+
+    :ets.lookup_element(ets_table, {table, :columns}, @column_info_position, :not_found)
   end
 end

--- a/packages/sync-service/test/electric/postgres/inspector/ets_inspector_test.exs
+++ b/packages/sync-service/test/electric/postgres/inspector/ets_inspector_test.exs
@@ -1,0 +1,34 @@
+defmodule Electric.Postgres.Inspector.EtsInspectorTest do
+  use Support.TransactionCase, async: true
+  import Support.ComponentSetup
+  import Support.DbStructureSetup
+  alias Electric.Postgres.Inspector.EtsInspector
+
+  describe "load_column_info/2" do
+    setup [:with_inspector, :with_basic_tables]
+
+    setup %{tables: [table | _], inspector: {EtsInspector, opts}} do
+      {:ok, %{opts: opts, table: table}}
+    end
+
+    test "returns column info for the table", %{opts: opts, table: table} do
+      assert {:ok, [%{name: "id"}, %{name: "value"}]} = EtsInspector.load_column_info(table, opts)
+    end
+
+    test "returns same value from ETS cache as the original call", %{opts: opts, table: table} do
+      original = EtsInspector.load_column_info(table, opts)
+      from_cache = EtsInspector.load_column_info(table, opts)
+      assert from_cache == original
+    end
+
+    test "returns same value from ETS cache as the original call with concurrent calls", %{
+      opts: opts,
+      table: table
+    } do
+      task = Task.async(fn -> EtsInspector.load_column_info(table, opts) end)
+      original = EtsInspector.load_column_info(table, opts)
+      from_cache = Task.await(task)
+      assert from_cache == original
+    end
+  end
+end

--- a/packages/sync-service/test/support/component_setup.ex
+++ b/packages/sync-service/test/support/component_setup.ex
@@ -102,7 +102,8 @@ defmodule Support.ComponentSetup do
     server = :"inspector #{full_test_name(ctx)}"
     pg_info_table = :"pg_info_table #{full_test_name(ctx)}"
 
-    {:ok, _} = EtsInspector.start_link(pg_info_table: pg_info_table, pool: ctx.pool, name: server)
+    {:ok, _} =
+      EtsInspector.start_link(pg_info_table: pg_info_table, pool: ctx.db_conn, name: server)
 
     %{inspector: {EtsInspector, pg_info_table: pg_info_table, server: server}}
   end


### PR DESCRIPTION
As found by @kevin-dp here: https://github.com/electric-sql/electric-next/actions/runs/10096466484/job/27919065981#step:13:17