### PR TITLE
feat: configure logical replication stream with our display settings

### DIFF
--- a/.changeset/cuddly-deers-reply.md
+++ b/.changeset/cuddly-deers-reply.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Configure logical replication stream with display settings.

--- a/packages/sync-service/lib/electric/postgres.ex
+++ b/packages/sync-service/lib/electric/postgres.ex
@@ -58,6 +58,7 @@ defmodule Electric.Postgres do
     * `TimeZone`           - affects the time zone offset Postgres uses for timestamptz and timetz values.
 
     * `extra_float_digits` - determines whether floating-point values are rounded or are encoded precisely.
+
     * `IntervalStyle`      - determines how Postgres interprets and formats interval values.
   """
   @spec display_settings :: [String.t()]

--- a/packages/sync-service/lib/electric/postgres.ex
+++ b/packages/sync-service/lib/electric/postgres.ex
@@ -32,4 +32,32 @@ defmodule Electric.Postgres do
       true
   """
   def supported_types_only_in_functions, do: ~w|interval|a
+
+  @display_settings [
+    "SET bytea_output = 'hex'",
+    "SET DateStyle = 'ISO, DMY'",
+    "SET TimeZone = 'UTC'",
+    "SET extra_float_digits = 1"
+  ]
+
+  @doc """
+  Configuration settings that affect formatting of values of certain types.
+
+  These settings should be set for the current session before executing any queries or
+  statements to safe-guard against non-standard configuration being used in the Postgres
+  database cluster or even the specific database Electric is configured to connect to.
+
+  The settings Electric is sensitive to are:
+
+    * `bytea_output`       - determines how Postgres encodes bytea values. It can use either Hex- or
+                             Escape-based encoding.
+
+    * `DateStyle`          - determines how Postgres interprets date values.
+
+    * `TimeZone`           - affects the time zone offset Postgres uses for timestamptz and timetz values.
+
+    * `extra_float_digits` - determines whether floating-point values are rounded or are encoded precisely.
+  """
+  @spec display_settings :: [String.t()]
+  def display_settings, do: @display_settings
 end

--- a/packages/sync-service/lib/electric/postgres.ex
+++ b/packages/sync-service/lib/electric/postgres.ex
@@ -37,7 +37,8 @@ defmodule Electric.Postgres do
     "SET bytea_output = 'hex'",
     "SET DateStyle = 'ISO, DMY'",
     "SET TimeZone = 'UTC'",
-    "SET extra_float_digits = 1"
+    "SET extra_float_digits = 1",
+    "SET IntervalStyle = 'iso_8601'"
   ]
 
   @doc """
@@ -57,6 +58,7 @@ defmodule Electric.Postgres do
     * `TimeZone`           - affects the time zone offset Postgres uses for timestamptz and timetz values.
 
     * `extra_float_digits` - determines whether floating-point values are rounded or are encoded precisely.
+    * `IntervalStyle`      - determines how Postgres interprets and formats interval values.
   """
   @spec display_settings :: [String.t()]
   def display_settings, do: @display_settings


### PR DESCRIPTION
This PR configures the logical replication stream to use well-defined display settings for formatting the value that come on the replication stream.