### PR TITLE
fix: Reduce memory footprint of initial sync by streaming data from storage

### DIFF
--- a/.changeset/grumpy-trains-battle.md
+++ b/.changeset/grumpy-trains-battle.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Reduce memory footprint of initial sync by streaming data from storage, for example a 35MB / 200k row table did require 550MB but now requires 50MB

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -269,9 +269,8 @@ defmodule Electric.Plug.ServeShapePlug do
         log =
           Shapes.get_log_stream(conn.assigns.config, shape_id, since: offset, up_to: last_offset)
 
-        snapshot
-        |> Stream.concat(log)
-        |> Stream.concat(@up_to_date)
+        [snapshot, log, @up_to_date]
+        |> Stream.concat()
         |> to_json_stream()
         |> Stream.chunk_every(500)
         |> send_stream(conn, 200)

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -308,13 +308,13 @@ defmodule Electric.Plug.ServeShapePlug do
   @json_list_end "]"
   @json_item_separator ","
   defp to_json_stream(items) do
-    [@json_list_start]
-    |> Stream.concat(
+    Stream.concat([
+      [@json_list_start],
       items
       |> Stream.map(&Jason.encode_to_iodata!/1)
-      |> Stream.intersperse(@json_item_separator)
-    )
-    |> Stream.concat([@json_list_end])
+      |> Stream.intersperse(@json_item_separator),
+      [@json_list_end]
+    ])
   end
 
   defp send_stream(stream, conn, status) do

--- a/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
+++ b/packages/sync-service/lib/electric/plug/serve_shape_plug.ex
@@ -9,7 +9,7 @@ defmodule Electric.Plug.ServeShapePlug do
   @before_all_offset LogOffset.before_all()
 
   # Control messages
-  @up_to_date [%{headers: %{control: "up-to-date"}}]
+  @up_to_date %{headers: %{control: "up-to-date"}}
   @must_refetch [%{headers: %{control: "must-refetch"}}]
 
   defmodule Params do
@@ -315,7 +315,7 @@ defmodule Electric.Plug.ServeShapePlug do
     if log == [] and conn.assigns.live do
       hold_until_change(conn, shape_id)
     else
-      send_resp(conn, 200, Jason.encode_to_iodata!(log ++ @up_to_date))
+      send_resp(conn, 200, Jason.encode_to_iodata!(log ++ [@up_to_date]))
     end
   end
 
@@ -354,10 +354,10 @@ defmodule Electric.Plug.ServeShapePlug do
       {^ref, :shape_rotation} ->
         # We may want to notify the client better that the shape ID had changed, but just closing the response
         # and letting the client handle it on reconnection is good enough.
-        send_resp(conn, 200, Jason.encode_to_iodata!(@up_to_date))
+        send_resp(conn, 200, Jason.encode_to_iodata!([@up_to_date]))
     after
       # If we timeout, return an empty body and 204 as there's no response body.
-      long_poll_timeout -> send_resp(conn, 204, Jason.encode_to_iodata!(@up_to_date))
+      long_poll_timeout -> send_resp(conn, 204, Jason.encode_to_iodata!([@up_to_date]))
     end
   end
 end

--- a/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/cub_db_storage.ex
@@ -83,7 +83,7 @@ defmodule Electric.ShapeCache.CubDbStorage do
   end
 
   def get_snapshot(shape_id, opts) do
-    results =
+    stream =
       opts.db
       |> CubDB.select(
         min_key: snapshot_start(shape_id),
@@ -91,10 +91,9 @@ defmodule Electric.ShapeCache.CubDbStorage do
       )
       |> Stream.flat_map(fn {_, items} -> items end)
       |> Stream.map(&storage_item_to_log_item/1)
-      |> Enum.to_list()
 
     # FIXME: this is naive while we don't have snapshot metadata to get real offset
-    {LogOffset.first(), results}
+    {LogOffset.first(), stream}
   end
 
   def get_log_stream(shape_id, offset, max_offset, opts) do

--- a/packages/sync-service/lib/electric/shape_cache/storage.ex
+++ b/packages/sync-service/lib/electric/shape_cache/storage.ex
@@ -25,7 +25,7 @@ defmodule Electric.ShapeCache.Storage do
           headers: log_header(),
           offset: LogOffset.t()
         }
-  @type log :: [log_entry()]
+  @type log :: Enumerable.t(log_entry())
 
   @type serialised_log_entry :: %{
           key: String.t(),


### PR DESCRIPTION
For example an initial sync of a 35MB / 200k row table did require 550MB memory but now requires 50MB.