### PR TITLE
docs: document format of shape log results and ShapeStream values

### DIFF
--- a/docs/api/clients/typescript.md
+++ b/docs/api/clients/typescript.md
@@ -50,6 +50,18 @@ By default, the `ShapeStream` parses the following Postgres types into native Ja
 All other types aren't parsed and are left in the string format as they were served by the HTTP endpoint.
 Arrays are parsed into JavaScript arrays, e.g. `"{{1,2},{3,4}}"` is parsed into `[[1,2],[3,4]]`.
 
+The `ShapeStream` can be configured with a custom parser that is an object mapping Postgres types to parsing functions for those types.
+For example, we can extend the [default parser](https://github.com/electric-sql/electric-next/blob/main/packages/typescript-client/src/parser.ts#L14-L22) to parse booleans into `1` or `0` instead of `true` or `false`:
+
+```ts
+const stream = new ShapeStream({
+  url: `http://localhost:3000/v1/shape/foo`,
+  parser: {
+    bool: (value: string) => value === `true` ? 1 : 0
+  }
+})
+```
+
 ### `Shape`
 
 ```tsx

--- a/docs/api/clients/typescript.md
+++ b/docs/api/clients/typescript.md
@@ -42,7 +42,7 @@ stream.subscribe(messages => {
 ```
 
 By default, the `ShapeStream` parses the following Postgres types into native JavaScript values:
-- `int2`, `int4`, and `float8` are parsed into JavaScript `Number`
+- `int2`, `int4`, `float4`, and `float8` are parsed into JavaScript `Number`
 - `int8` is parsed into a JavaScript `BigInt`
 - `bool` is parsed into a JavaScript `Boolean`
 - `json` and `jsonb` are parsed into JavaScript values/arrays/objects using `JSON.parse`

--- a/docs/api/clients/typescript.md
+++ b/docs/api/clients/typescript.md
@@ -41,7 +41,7 @@ stream.subscribe(messages => {
 })
 ```
 
-By default, the `ShapeStream` parses the following Postgres types into native JavaScript values:
+By default, `ShapeStream` parses the following Postgres types into native JavaScript values:
 - `int2`, `int4`, `float4`, and `float8` are parsed into JavaScript `Number`
 - `int8` is parsed into a JavaScript `BigInt`
 - `bool` is parsed into a JavaScript `Boolean`

--- a/docs/api/clients/typescript.md
+++ b/docs/api/clients/typescript.md
@@ -46,9 +46,9 @@ By default, `ShapeStream` parses the following Postgres types into native JavaSc
 - `int8` is parsed into a JavaScript `BigInt`
 - `bool` is parsed into a JavaScript `Boolean`
 - `json` and `jsonb` are parsed into JavaScript values/arrays/objects using `JSON.parse`
+- Postgres Arrays are parsed into JavaScript arrays, e.g. `"{{1,2},{3,4}}"` is parsed into `[[1,2],[3,4]]`
 
 All other types aren't parsed and are left in the string format as they were served by the HTTP endpoint.
-Arrays are parsed into JavaScript arrays, e.g. `"{{1,2},{3,4}}"` is parsed into `[[1,2],[3,4]]`.
 
 The `ShapeStream` can be configured with a custom parser that is an object mapping Postgres types to parsing functions for those types.
 For example, we can extend the [default parser](https://github.com/electric-sql/electric-next/blob/main/packages/typescript-client/src/parser.ts#L14-L22) to parse booleans into `1` or `0` instead of `true` or `false`:

--- a/docs/api/clients/typescript.md
+++ b/docs/api/clients/typescript.md
@@ -41,6 +41,15 @@ stream.subscribe(messages => {
 })
 ```
 
+By default, the `ShapeStream` parses the following Postgres types into native JavaScript values:
+- `int2`, `int4`, and `float8` are parsed into JavaScript `Number`
+- `int8` is parsed into a JavaScript `BigInt`
+- `bool` is parsed into a JavaScript `Boolean`
+- `json` and `jsonb` are parsed into JavaScript values/arrays/objects using `JSON.parse`
+
+All other types aren't parsed and are left in the string format as they were served by the HTTP endpoint.
+Arrays are parsed into JavaScript arrays, e.g. `"{{1,2},{3,4}}"` is parsed into `[[1,2],[3,4]]`.
+
 ### `Shape`
 
 ```tsx

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -38,7 +38,7 @@ When you sync a shape from Electric, you get the data in the form of a log of lo
 
 The `offset` that you see in the messages and provide as the `?offset=...` query parameter in your request identifies a position in the log. The messages you see in the response are shape log entries (the ones with `value`s and `action` headers) and control messages (the ones with `control` headers).
 
-The Shape Log is similar conceptually to the logical replication stream from Postgres. Except that instead of getting all the database operations, you're getting the ones that affect the data in your Shape. It's then the responsibility of the client to consume the log and materialize out the current value of the shape.
+The Shape Log is similar conceptually to the logical replication stream from Postgres. Except that instead of getting all the database operations, you're getting the ones that affect the data in your Shape. It's then the responsibility of the client to consume the log and materialize out the current value of the shape. The values included in the shape log are strings formatted according to Postgres' display settings. The [OpenAPI](https://www.openapis.org/what-is-openapi) specification defines the display settings the HTTP API adheres to.
 
 <figure>
   <a href="/img/api/shape-log.jpg">
@@ -63,13 +63,13 @@ Sometimes a log can fit in a single response. Sometimes it's too big and require
 
 ### Control messages
 
-The client will then recieve an `up-to-date` control message at the end of the response data:
+The client will then receive an `up-to-date` control message at the end of the response data:
 
 ```json
 {"headers": {"control": "up-to-date"}}
 ```
 
-This indicates that the client has all the data that the server was aware of when fulfilling the request. The client can then switch into live mode to recieve real-time updates.
+This indicates that the client has all the data that the server was aware of when fulfilling the request. The client can then switch into live mode to receive real-time updates.
 
 ::: info Must-refetch
 Note that the other control message is `must-refetch` which indicates that the client must throwaway their local shape data and re-sync from scratch:

--- a/docs/electric-api.yaml
+++ b/docs/electric-api.yaml
@@ -243,6 +243,15 @@ paths:
                         - for inserts it will contain the whole row
                         - for updates it will contain the primary key and the changed values
                         - for deletes it will contain just the primary key
+                        
+                        The values are strings that are formatted according to Postgres' display settings.
+                        Some Postgres types support several display settings, we format values consistently according to the following display settings:
+                        
+                        - `bytea_output = 'hex'`
+                        - `DateStyle = 'ISO, DMY'`
+                        - `TimeZone = 'UTC'`
+                        - `IntervalStyle = 'iso_8601'`
+                        - `extra_float_digits = 1`
                 example:
                   - headers:
                       action: insert

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -120,11 +120,11 @@ x-electric-shape-id: 3833821-1721299734314
 x-electric-chunk-last-offset: 0_0
 etag: 3833821-1721299734314:-1:0_0
 
-[{"offset":"0_0","value":{"id":1,"name":"Alice","value":3.14},"key":"\"public\".\"foo\"/1","headers":{"action"
-:"insert"}},{"offset":"0_0","value":{"id":2,"name":"Bob","value":2.71},"key":"\"public\".\"foo\"/2","headers":
-{"action":"insert"}},{"offset":"0_0","value":{"id":3,"name":"Charlie","value":-1.618},"key":"\"public\".\"foo\
-"/3","headers":{"action":"insert"}},{"offset":"0_0","value":{"id":4,"name":"David","value":1.414},"key":"\"pub
-lic\".\"foo\"/4","headers":{"action":"insert"}},{"offset":"0_0","value":{"id":5,"name":"Eve","value":0.0},"key
+[{"offset":"0_0","value":{"id":"1","name":"Alice","value":"3.14"},"key":"\"public\".\"foo\"/1","headers":{"action"
+:"insert"}},{"offset":"0_0","value":{"id":"2","name":"Bob","value":"2.71"},"key":"\"public\".\"foo\"/2","headers":
+{"action":"insert"}},{"offset":"0_0","value":{"id":"3","name":"Charlie","value":"-1.618"},"key":"\"public\".\"foo\
+"/3","headers":{"action":"insert"}},{"offset":"0_0","value":{"id":"4","name":"David","value":"1.414"},"key":"\"pub
+lic\".\"foo\"/4","headers":{"action":"insert"}},{"offset":"0_0","value":{"id":"5","name":"Eve","value":"0.0"},"key
 ":"\"public\".\"foo\"/5","headers":{"action":"insert"}},{"headers":{"control":"up-to-date"}}]
 ```
 


### PR DESCRIPTION
This PR extends the docs to explain that HTTP endpoint returns values as strings formatted according to specific PG display settings and that the `ShapeStream` parses basic types into JS and can be configured with a custom parser.