### PR TITLE
feat: type modifiers for unknown types in schema

### DIFF
--- a/.changeset/nine-bulldogs-shout.md
+++ b/.changeset/nine-bulldogs-shout.md
@@ -1,0 +1,5 @@
+---
+"@core/sync-service": patch
+---
+
+Add type modifier information in the schema for types that are not built-in.

--- a/packages/sync-service/lib/electric/schema.ex
+++ b/packages/sync-service/lib/electric/schema.ex
@@ -12,7 +12,8 @@ defmodule Electric.Schema do
           optional(:length) => String.t(),
           optional(:precision) => String.t(),
           optional(:scale) => String.t(),
-          optional(:fields) => String.t()
+          optional(:fields) => String.t(),
+          optional(:type_mod) => integer()
         }
 
   @bit_types ["bit", "varbit"]
@@ -98,6 +99,12 @@ defmodule Electric.Schema do
       <<type_mod - 4::signed-integer-32>>
 
     Map.merge(schema, %{precision: precision, scale: scale})
+  end
+
+  defp add_modifier(schema, %{type_mod: type_mod}) when type_mod > -1 do
+    # It's not a built-in type so we don't know how to interpret its type modifier.
+    # Therefore we include the type modifier as is in the schema.
+    Map.put(schema, :type_mod, type_mod)
   end
 
   defp add_modifier(schema, _), do: schema


### PR DESCRIPTION
This PR adds information about type modifiers of unknown types in the schema.
For example, if using a `vector(55)` type defined by the `pgvector` extension, then we will include `type_mod: 55` in the information for that column in `x-electric-schema`.

I'm not sure how to best unit test this. I don't think we want to load an extension just for the purpose of testing this, unless there is a simple way to load an extension in our test environment?