### PR TITLE
fix: IS [NOT] DISTINCT FROM in WHERE clauses

### DIFF
--- a/packages/sync-service/lib/electric/replication/eval/parser.ex
+++ b/packages/sync-service/lib/electric/replication/eval/parser.ex
@@ -330,7 +330,7 @@ defmodule Electric.Replication.Eval.Parser do
     args = [expr.lexpr, expr.rexpr]
     fun = if kind == :AEXPR_DISTINCT, do: :values_distinct?, else: :values_not_distinct?
 
-    with {:ok, func} <- find_operator_func(["="], args, expr.location, refs, env),
+    with {:ok, func} <- find_operator_func(["<>"], args, expr.location, refs, env),
          {:ok, reduced} <- maybe_reduce(func) do
       # This is suboptimal at evaluation time, in that it duplicates same argument sub-expressions
       # to be at this level, as well as at the `=` operator level. I'm not sure how else to model

--- a/packages/sync-service/lib/electric/replication/eval/parser.ex
+++ b/packages/sync-service/lib/electric/replication/eval/parser.ex
@@ -223,6 +223,7 @@ defmodule Electric.Replication.Eval.Parser do
       {:AEXPR_LIKE, _} -> handle_binary_operator(expr, refs, env)
       {:AEXPR_ILIKE, _} -> handle_binary_operator(expr, refs, env)
       {:AEXPR_DISTINCT, _} -> handle_distinct(expr, refs, env)
+      {:AEXPR_NOT_DISTINCT, _} -> handle_distinct(expr, refs, env)
       {:AEXPR_IN, _} -> handle_in(expr, refs, env)
       _ -> {:error, {loc, "expression #{identifier(expr.name)} is not currently supported"}}
     end
@@ -328,7 +329,12 @@ defmodule Electric.Replication.Eval.Parser do
 
   defp handle_distinct(%PgQuery.A_Expr{kind: kind} = expr, refs, env) do
     args = [expr.lexpr, expr.rexpr]
-    fun = if kind == :AEXPR_DISTINCT, do: :values_distinct?, else: :values_not_distinct?
+
+    fun =
+      case kind do
+        :AEXPR_DISTINCT -> :values_distinct?
+        :AEXPR_NOT_DISTINCT -> :values_not_distinct?
+      end
 
     with {:ok, func} <- find_operator_func(["<>"], args, expr.location, refs, env),
          {:ok, reduced} <- maybe_reduce(func) do

--- a/packages/sync-service/test/electric/replication/eval/parser_test.exs
+++ b/packages/sync-service/test/electric/replication/eval/parser_test.exs
@@ -369,7 +369,7 @@ defmodule Electric.Replication.Eval.ParserTest do
       assert %Const{value: true, type: :bool} = result
     end
 
-    test "should support IS and IS NOT NULL" do
+    test "should support IS [NOT] NULL" do
       env = Env.new()
 
       assert {:ok, %Expr{eval: result}} =
@@ -388,7 +388,7 @@ defmodule Electric.Replication.Eval.ParserTest do
       assert %Const{value: true, type: :bool} = result
     end
 
-    test "should support IS and IS NOT TRUE/FALSE" do
+    test "should support IS [NOT] TRUE/FALSE" do
       env = Env.new()
 
       assert {:ok, %Expr{eval: result}} =
@@ -397,9 +397,9 @@ defmodule Electric.Replication.Eval.ParserTest do
       assert %Const{value: true, type: :bool} = result
 
       assert {:ok, %Expr{eval: result}} =
-               Parser.parse_and_validate_expression(~S|false IS NOT FALSE|, %{}, env)
+               Parser.parse_and_validate_expression(~S|false IS NOT TRUE|, %{}, env)
 
-      assert %Const{value: false, type: :bool} = result
+      assert %Const{value: true, type: :bool} = result
 
       assert {:ok, %Expr{eval: result}} =
                Parser.parse_and_validate_expression(~S|null IS NOT FALSE|, %{}, env)
@@ -407,7 +407,7 @@ defmodule Electric.Replication.Eval.ParserTest do
       assert %Const{value: true, type: :bool} = result
 
       assert {:ok, %Expr{eval: result}} =
-               Parser.parse_and_validate_expression(~S|null IS TRUE|, %{}, env)
+               Parser.parse_and_validate_expression(~S|null IS FALSE|, %{}, env)
 
       assert %Const{value: false, type: :bool} = result
 
@@ -419,6 +419,7 @@ defmodule Electric.Replication.Eval.ParserTest do
   describe "parse_and_validate_expression/3 default env" do
     test "can compare integers" do
       assert {:ok, _} = Parser.parse_and_validate_expression(~S|id != 1|, %{["id"] => :int8})
+      assert {:ok, _} = Parser.parse_and_validate_expression(~S|id <> 1|, %{["id"] => :int8})
       assert {:ok, _} = Parser.parse_and_validate_expression(~S|id > 1|, %{["id"] => :int8})
       assert {:ok, _} = Parser.parse_and_validate_expression(~S|id < 1|, %{["id"] => :int8})
       assert {:ok, _} = Parser.parse_and_validate_expression(~S|id >= 1|, %{["id"] => :int8})


### PR DESCRIPTION
Part of https://github.com/electric-sql/electric-next/issues/241.