### PR TITLE
fix: Fix broken Netlify build

### DIFF
--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: ['main']
   pull_request:
+    paths:
+      - "!docs/**"
 
 permissions:
   contents: read

--- a/.github/workflows/ts_test.yml
+++ b/.github/workflows/ts_test.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: ['main']
   pull_request:
+    paths:
+      - "!docs/**"
 
 permissions:
   contents: read

--- a/docs/api/clients/typescript.md
+++ b/docs/api/clients/typescript.md
@@ -46,7 +46,7 @@ By default, `ShapeStream` parses the following Postgres types into native JavaSc
 - `int8` is parsed into a JavaScript `BigInt`
 - `bool` is parsed into a JavaScript `Boolean`
 - `json` and `jsonb` are parsed into JavaScript values/arrays/objects using `JSON.parse`
-- Postgres Arrays are parsed into JavaScript arrays, e.g. `"{{1,2},{3,4}}"` is parsed into `[[1,2],[3,4]]`
+- Postgres Arrays are parsed into JavaScript arrays, e.g. `"&#123;{1,2},{3,4}}"` is parsed into `[[1,2],[3,4]]`
 
 All other types aren't parsed and are left in the string format as they were served by the HTTP endpoint.
 


### PR DESCRIPTION
I have no idea why but Netlify chokes on the first opening brace and reports an error on a different line in this file. I had to guess which part of the content was triggering the error because the location information in the error message was bogus.

```
$ npx vitepress build .

  vitepress v1.3.1

x Build failed in 427ms
✖ building client + server bundles...
build error:
[vite:vue] [plugin vite:vue] api/clients/typescript.md (32:85): Error parsing JavaScript expression: Unexpected token, expected "," (1:4) file:
/home/alco/code/electric-sql/next/docs/api/clients/typescript.md:32:85 [vite:vue] [plugin vite:vue] api/clients/typescript.md (32:85): Error parsing JavaScript expression: Unexpected token, expected "," (1:4) file:
/home/alco/code/electric-sql/next/docs/api/clients/typescript.md:32:85 SyntaxError: Error parsing JavaScript expression: Unexpected token, expected "," (1:4)
```