### PR TITLE
fix(ci): Remove path filters for our CI workflows

### DIFF
--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: ['main']
   pull_request:
-    paths:
-      - "!docs/**"
 
 permissions:
   contents: read

--- a/.github/workflows/ts_test.yml
+++ b/.github/workflows/ts_test.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: ['main']
   pull_request:
-    paths:
-      - "!docs/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
This partially reverts c237e9c34702c05ef8440b1e4a2220ae9e11d578 which made it so that no CI workflows would get run for pull requests.